### PR TITLE
fix(geolocation): upgrade LocAR.js to 0.2.x

### DIFF
--- a/.changeset/locar-0-2.md
+++ b/.changeset/locar-0-2.md
@@ -1,0 +1,5 @@
+---
+"@omnidotdev/rdk": patch
+---
+
+Upgrade LocAR.js to 0.2.x. The geolocation backend now renders the camera feed via LocAR's aspect-ratio-preserving DOM video element behind a transparent canvas (instead of a stretched `scene.background` texture), and tears down the media stream and video element on session end.

--- a/apps/geolocation-demo/package.json
+++ b/apps/geolocation-demo/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@omnidotdev/rdk": "workspace:*",
     "@react-three/fiber": "^9.5.0",
-    "locar": "^0.1.8",
+    "locar": "^0.2.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "three": "^0.183.0"

--- a/apps/geolocation-demo/src/App.tsx
+++ b/apps/geolocation-demo/src/App.tsx
@@ -7,174 +7,178 @@ import {
 } from "@omnidotdev/rdk";
 import { Canvas } from "@react-three/fiber";
 import { Compass, GPSPin, Landmark } from "components";
+import { useState } from "react";
 
-// set these to your preferred location
-const BASE_LATITUDE = 48.68951980519457,
-  BASE_LONGITUDE = -113.6363247804274;
+interface LatLon {
+  lat: number;
+  lon: number;
+}
 
-// spread anchors around the base location
-const COORDS = {
-  center: { lat: BASE_LATITUDE, lon: BASE_LONGITUDE },
-  north: { lat: BASE_LATITUDE + 0.0005, lon: BASE_LONGITUDE },
-  south: { lat: BASE_LATITUDE - 0.0005, lon: BASE_LONGITUDE },
-  east: { lat: BASE_LATITUDE, lon: BASE_LONGITUDE + 0.0007 },
-  west: { lat: BASE_LATITUDE, lon: BASE_LONGITUDE - 0.0007 },
-  northeast: { lat: BASE_LATITUDE + 0.0003, lon: BASE_LONGITUDE + 0.0004 },
+/**
+ * Anchors, lines, and zones placed relative to a base location. The base is the
+ * user's live GPS position, so everything renders around wherever they stand.
+ */
+const DemoScene = ({ base }: { base: LatLon }) => {
+  const { lat, lon } = base;
+
+  // spread anchors around the base location
+  const coords = {
+    center: { lat, lon },
+    north: { lat: lat + 0.0005, lon },
+    south: { lat: lat - 0.0005, lon },
+    east: { lat, lon: lon + 0.0007 },
+    west: { lat, lon: lon - 0.0007 },
+    northeast: { lat: lat + 0.0003, lon: lon + 0.0004 },
+  };
+
+  // sample path coordinates (GeoJSON-style: [lon, lat, elevation?])
+  const pathCoordinates: Array<[number, number, number?]> = [
+    [lon - 0.0003, lat - 0.0002, 2],
+    [lon - 0.0001, lat - 0.0001, 2],
+    [lon + 0.0001, lat, 2],
+    [lon + 0.0003, lat + 0.0001, 2],
+    [lon + 0.0005, lat + 0.0003, 2],
+  ];
+
+  // sample dashed path coordinates (parallel to solid line, offset north)
+  const dashedPathCoordinates: Array<[number, number, number?]> = [
+    [lon - 0.0003, lat - 0.0001, 2],
+    [lon - 0.0001, lat, 2],
+    [lon + 0.0001, lat + 0.0001, 2],
+    [lon + 0.0003, lat + 0.0002, 2],
+    [lon + 0.0005, lat + 0.0004, 2],
+  ];
+
+  // sample polygon coordinates (area/zone)
+  const zoneCoordinates: Array<[number, number, number?]> = [
+    [lon - 0.0006, lat + 0.0003, 1],
+    [lon - 0.0003, lat + 0.0003, 1],
+    [lon - 0.0003, lat + 0.0006, 1],
+    [lon - 0.0006, lat + 0.0006, 1],
+  ];
+
+  return (
+    <>
+      <GeolocationAnchor
+        latitude={coords.center.lat}
+        longitude={coords.center.lon}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🟠 Orange box attached!")}
+      >
+        <mesh scale={3}>
+          <boxGeometry args={[0.4, 0.4, 0.4]} />
+          <meshStandardMaterial color="orange" />
+        </mesh>
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        latitude={coords.north.lat}
+        longitude={coords.north.lon}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🎯 Main GPS Pin attached!")}
+      >
+        <GPSPin isAnimated color="#ff4444" scale={15} />
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        latitude={coords.south.lat}
+        longitude={coords.south.lon}
+        altitude={10}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🔴 Large red cube attached!")}
+      >
+        <mesh scale={1}>
+          <boxGeometry args={[20, 20, 20]} />
+          <meshStandardMaterial
+            color="red"
+            emissive="red"
+            emissiveIntensity={0.3}
+          />
+        </mesh>
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        isBillboard={false}
+        latitude={coords.east.lat}
+        longitude={coords.east.lon}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🗼 Tower attached!")}
+      >
+        <Landmark isAnimated type="tower" color="#4a90e2" scale={10} />
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        latitude={coords.west.lat}
+        longitude={coords.west.lon}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🧭 Compass attached!")}
+      >
+        <Compass isAnimated scale={1.2} />
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        isBillboard={false}
+        latitude={coords.northeast.lat}
+        longitude={coords.northeast.lon}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🏢 Building attached!")}
+      >
+        <Landmark type="building" color="#27ae60" scale={8} />
+      </GeolocationAnchor>
+
+      <GeolocationAnchor
+        latitude={coords.center.lat}
+        longitude={coords.center.lon + 0.0003}
+        // biome-ignore lint/suspicious/noConsole: demo app
+        onAttach={() => console.log("🏛️ Monument attached!")}
+      >
+        <Landmark isAnimated type="monument" color="#8e44ad" scale={0.8} />
+      </GeolocationAnchor>
+
+      <GeoLine coordinates={pathCoordinates} color="#ff4444" />
+
+      <GeoLine coordinates={dashedPathCoordinates} color="#ffaa00" isDashed />
+
+      <GeoPolygon coordinates={zoneCoordinates} color="#4488ff" opacity={0.5} />
+    </>
+  );
 };
 
-// sample path coordinates (GeoJSON-style: [lon, lat, elevation?])
-const PATH_COORDINATES: Array<[number, number, number?]> = [
-  [BASE_LONGITUDE - 0.0003, BASE_LATITUDE - 0.0002, 2],
-  [BASE_LONGITUDE - 0.0001, BASE_LATITUDE - 0.0001, 2],
-  [BASE_LONGITUDE + 0.0001, BASE_LATITUDE, 2],
-  [BASE_LONGITUDE + 0.0003, BASE_LATITUDE + 0.0001, 2],
-  [BASE_LONGITUDE + 0.0005, BASE_LATITUDE + 0.0003, 2],
-];
+const App = () => {
+  // base location for all anchors; captured from the first live GPS fix so the
+  // scene renders around the user wherever they are
+  const [base, setBase] = useState<LatLon | null>(null);
 
-// sample dashed path coordinates (parallel to solid line, offset north)
-const DASHED_PATH_COORDINATES: Array<[number, number, number?]> = [
-  [BASE_LONGITUDE - 0.0003, BASE_LATITUDE - 0.0002 + 0.0001, 2],
-  [BASE_LONGITUDE - 0.0001, BASE_LATITUDE - 0.0001 + 0.0001, 2],
-  [BASE_LONGITUDE + 0.0001, BASE_LATITUDE + 0.0001, 2],
-  [BASE_LONGITUDE + 0.0003, BASE_LATITUDE + 0.0001 + 0.0001, 2],
-  [BASE_LONGITUDE + 0.0005, BASE_LATITUDE + 0.0003 + 0.0001, 2],
-];
+  return (
+    <Canvas>
+      {/* lighting */}
+      <ambientLight intensity={1.0} />
+      <hemisphereLight intensity={0.8} />
+      <directionalLight position={[10, 10, 10]} intensity={2} castShadow />
+      <directionalLight position={[-10, 10, -10]} intensity={1} />
 
-// sample polygon coordinates (area/zone)
-const ZONE_COORDINATES: Array<[number, number, number?]> = [
-  [BASE_LONGITUDE - 0.0006, BASE_LATITUDE + 0.0003, 1],
-  [BASE_LONGITUDE - 0.0003, BASE_LATITUDE + 0.0003, 1],
-  [BASE_LONGITUDE - 0.0003, BASE_LATITUDE + 0.0006, 1],
-  [BASE_LONGITUDE - 0.0006, BASE_LATITUDE + 0.0006, 1],
-];
-
-const App = () => (
-  <Canvas>
-    {/* lighting */}
-    <ambientLight intensity={1.0} />
-    <hemisphereLight intensity={0.8} />
-    <directionalLight position={[10, 10, 10]} intensity={2} castShadow />
-    <directionalLight position={[-10, 10, -10]} intensity={1} />
-
-    <XR>
-      <GeolocationSession
-        options={{
-          // enable fake GPS for testing: uncomment and adjust to preferred location
-          // fakeLat: BASE_LATITUDE,
-          // fakeLon: BASE_LONGITUDE,
-          // handle GPS position updates
-          onGpsUpdate: (pos, distMoved) => {
-            // biome-ignore lint/suspicious/noConsole: demo app
-            console.group("GPS Update");
-            // biome-ignore lint/suspicious/noConsole: demo app
-            console.log(
-              `Position: ${pos.coords.latitude}, ${pos.coords.longitude}`,
-            );
-            // biome-ignore lint/suspicious/noConsole: demo app
-            console.log(`Distance Moved: ${distMoved}`);
-            // biome-ignore lint/suspicious/noConsole: demo app
-            console.groupEnd();
-          },
-        }}
-      >
-        <GeolocationAnchor
-          latitude={COORDS.center.lat}
-          longitude={COORDS.center.lon}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🟠 Orange box attached!")}
+      <XR>
+        <GeolocationSession
+          options={{
+            // enable fake GPS for testing on desktop: uncomment and adjust
+            // (example: Missoula, MT)
+            // fakeLat: 46.8721,
+            // fakeLon: -114.009,
+            onGpsUpdate: (pos) => {
+              // lock the base to the first GPS fix
+              setBase((prev) =>
+                prev
+                  ? prev
+                  : { lat: pos.coords.latitude, lon: pos.coords.longitude },
+              );
+            },
+          }}
         >
-          <mesh scale={3}>
-            <boxGeometry args={[0.4, 0.4, 0.4]} />
-            <meshStandardMaterial color="orange" />
-          </mesh>
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          latitude={COORDS.north.lat}
-          longitude={COORDS.north.lon}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🎯 Main GPS Pin attached!")}
-          onGpsUpdate={(pos) =>
-            // biome-ignore lint/suspicious/noConsole: demo app
-            console.log(
-              `📍 Anchor GPS update: ${pos.coords.latitude}, ${pos.coords.longitude}`,
-            )
-          }
-        >
-          <GPSPin isAnimated color="#ff4444" scale={15} />
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          latitude={COORDS.south.lat}
-          longitude={COORDS.south.lon}
-          altitude={10}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🔴 Large red cube attached!")}
-        >
-          <mesh scale={1}>
-            <boxGeometry args={[20, 20, 20]} />
-            <meshStandardMaterial
-              color="red"
-              emissive="red"
-              emissiveIntensity={0.3}
-            />
-          </mesh>
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          isBillboard={false}
-          latitude={COORDS.east.lat}
-          longitude={COORDS.east.lon}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🗼 Tower attached!")}
-        >
-          <Landmark isAnimated type="tower" color="#4a90e2" scale={10} />
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          latitude={COORDS.west.lat}
-          longitude={COORDS.west.lon}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🧭 Compass attached!")}
-        >
-          <Compass isAnimated scale={1.2} />
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          isBillboard={false}
-          latitude={COORDS.northeast.lat}
-          longitude={COORDS.northeast.lon}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🏢 Building attached!")}
-        >
-          <Landmark type="building" color="#27ae60" scale={8} />
-        </GeolocationAnchor>
-
-        <GeolocationAnchor
-          latitude={COORDS.center.lat}
-          longitude={COORDS.center.lon + 0.0003}
-          // biome-ignore lint/suspicious/noConsole: demo app
-          onAttach={() => console.log("🏛️ Monument attached!")}
-        >
-          <Landmark isAnimated type="monument" color="#8e44ad" scale={0.8} />
-        </GeolocationAnchor>
-
-        <GeoLine coordinates={PATH_COORDINATES} color="#ff4444" />
-
-        <GeoLine
-          coordinates={DASHED_PATH_COORDINATES}
-          color="#ffaa00"
-          isDashed
-        />
-
-        <GeoPolygon
-          coordinates={ZONE_COORDINATES}
-          color="#4488ff"
-          opacity={0.5}
-        />
-      </GeolocationSession>
-    </XR>
-  </Canvas>
-);
+          {base && <DemoScene base={base} />}
+        </GeolocationSession>
+      </XR>
+    </Canvas>
+  );
+};
 
 export default App;

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
       "dependencies": {
         "@omnidotdev/rdk": "workspace:*",
         "@react-three/fiber": "^9.5.0",
-        "locar": "^0.1.8",
+        "locar": "^0.2.3",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "three": "^0.183.0",
@@ -119,7 +119,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.183.0",
         "jsdom": "^29.0.0",
-        "locar": "^0.1.8",
+        "locar": "^0.2.3",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "three": "^0.183.0",
@@ -133,7 +133,7 @@
         "@ar-js-org/ar.js": "^3.4.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/xr": "^6.6.29",
-        "locar": "^0.1.8",
+        "locar": "^0.2.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "three": "^0.183.0",
@@ -962,7 +962,7 @@
 
     "local-pkg": ["local-pkg@1.1.2", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A=="],
 
-    "locar": ["locar@0.1.8", "", { "dependencies": { "three": "^0.180.0" } }, "sha512-qQ3+n4knzagUZzM7Dsb37s4AgcMJhKupo1ZtBpoQlqTU/CbeRtJsAK2ZwsA3WtKO/AUW2Z/gNqNbEhdAdGsKPA=="],
+    "locar": ["locar@0.2.3", "", { "dependencies": { "minimatch": "^9.0.7", "three": "^0.180.0" } }, "sha512-cTerHqjbSUahHlVhGoCqeozuRuGgjl8jeVsrpkRqLkq8sdSKC5RNacOqhIYPoQGSbUp4857kZey/v4Fh4iWfHw=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -1008,7 +1008,7 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -1381,6 +1381,8 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@microsoft/api-extractor/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 
     "@microsoft/api-extractor/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
 

--- a/packages/rdk/package.json
+++ b/packages/rdk/package.json
@@ -70,7 +70,7 @@
     "@ar-js-org/ar.js": "^3.4.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/xr": "^6.6.29",
-    "locar": "^0.1.8",
+    "locar": "^0.2.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "three": "^0.183.0"
@@ -97,7 +97,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.183.0",
     "jsdom": "^29.0.0",
-    "locar": "^0.1.8",
+    "locar": "^0.2.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "three": "^0.183.0",

--- a/packages/rdk/src/geolocation/GeoLine.tsx
+++ b/packages/rdk/src/geolocation/GeoLine.tsx
@@ -15,7 +15,7 @@ import { LineMaterial } from "three/addons/lines/LineMaterial.js";
 
 import useGeolocationBackend from "./useGeolocationBackend";
 
-import type { LocationBased as LocAR } from "locar";
+import type { LocAR } from "locar";
 import type { ColorRepresentation } from "three";
 
 export interface GeoLineProps {

--- a/packages/rdk/src/geolocation/GeoPolygon.tsx
+++ b/packages/rdk/src/geolocation/GeoPolygon.tsx
@@ -12,7 +12,7 @@ import {
 
 import useGeolocationBackend from "./useGeolocationBackend";
 
-import type { LocationBased as LocAR } from "locar";
+import type { LocAR } from "locar";
 import type { Side } from "three";
 
 export interface GeoPolygonProps {

--- a/packages/rdk/src/geolocation/geolocationBackend.ts
+++ b/packages/rdk/src/geolocation/geolocationBackend.ts
@@ -1,9 +1,5 @@
 import { BACKEND_TYPES } from "lib/types/engine";
-import {
-  DeviceOrientationControls,
-  LocationBased as LocAR,
-  Webcam,
-} from "locar";
+import { DeviceOrientationControls, LocAR, Webcam } from "locar";
 
 import type { Backend, BackendInitArgs } from "lib/types/engine";
 import type { Camera, Group, Scene, WebGLRenderer } from "three";
@@ -88,6 +84,10 @@ const createGeolocationBackend = (
   let webcam: Webcam | null = null;
   let deviceOrientation: DeviceOrientationControls | null = null;
   let resizeHandler: (() => void) | undefined;
+  // LocAR 0.2.x renders the camera feed into its own <video> element appended to
+  // the document (there is no stop()/dispose() on Webcam), so we track it to tear
+  // the stream down and remove the element on session end
+  let webcamVideoEl: HTMLVideoElement | null = null;
 
   let gpsUpdateHandler: ((data: GpsUpdateEvent) => void) | null = null;
 
@@ -158,13 +158,29 @@ const createGeolocationBackend = (
       // location-based handler
       locar = new LocAR(scene, camera);
 
-      // video background
+      // LocAR 0.2.x renders the camera feed as a DOM <video> element (sized to
+      // preserve aspect ratio) behind the canvas, rather than a stretched
+      // `scene.background` texture. Clear the WebGL canvas to transparent so the
+      // feed shows through
+      renderer.setClearAlpha?.(0);
+
+      // snapshot existing videos so we can identify the element LocAR creates
+      const existingVideos = new Set(document.querySelectorAll("video"));
+
+      // video background (LocAR creates and appends its own <video> element)
       webcam = new Webcam(
         (options?.webcamConstraints ?? {
           video: { facingMode: "environment" },
-          // TODO remove `as any` once fixed upstream (LocAR.js)
+          // TODO narrow `webcamConstraints` to LocAR's `{ video: { facingMode } }` shape
         }) as any,
       );
+
+      for (const video of document.querySelectorAll("video")) {
+        if (!existingVideos.has(video)) {
+          webcamVideoEl = video as HTMLVideoElement;
+          break;
+        }
+      }
 
       gpsUpdateHandler = (data: GpsUpdateEvent) => {
         // store the last known position for new anchors
@@ -181,10 +197,6 @@ const createGeolocationBackend = (
       };
 
       locar.on("gpsupdate", gpsUpdateHandler);
-
-      webcam.on("webcamstarted", (evt) => {
-        scene.background = evt.texture;
-      });
 
       webcam.on("webcamerror", (err) => {
         console.error("[geolocationBackend] webcam error:", err);
@@ -209,8 +221,8 @@ const createGeolocationBackend = (
         console.error("[geolocationBackend] gps error:", err);
       });
 
-      // start GPS
-      locar.startGps();
+      // start GPS (0.2.x returns a Promise; errors surface via the gpserror event)
+      void locar.startGps();
 
       // optional boot in fake mode
       if (
@@ -270,8 +282,18 @@ const createGeolocationBackend = (
       }
 
       locar?.stopGps?.();
-      // TODO remove `as any` once fixed upstream (LocAR.js)
-      (webcam as any)?.stop?.();
+
+      // LocAR 0.2.x has no Webcam teardown, so stop the media stream and remove
+      // the <video> element it appended, then restore canvas opacity
+      if (webcamVideoEl) {
+        const stream = webcamVideoEl.srcObject as MediaStream | null;
+        for (const track of stream?.getTracks() ?? []) track.stop();
+        webcamVideoEl.srcObject = null;
+        webcamVideoEl.remove();
+        webcamVideoEl = null;
+      }
+      rendererRef?.setClearAlpha?.(1);
+
       deviceOrientation?.dispose?.();
 
       if (resizeHandler) {


### PR DESCRIPTION
Upgrades LocAR.js `^0.1.8` -> `^0.2.3`, adapting to the 0.2.x API. Supersedes #89 (Renovate's blind bump would not compile against the new API).

## What changed
- `LocationBased` -> `LocAR` import rename (backend + GeoLine/GeoPolygon).
- 0.2.x removed the `scene.background` webcam texture; it now renders an aspect-ratio-preserving DOM `<video>` behind the canvas. Backend clears the WebGL canvas to transparent so the feed shows through.
- Media stream + video element are torn down on session dispose (0.2.x `Webcam` exposes no `stop()`).
- Changeset added. Build + 69 tests pass.

## Fixes / relates to
- Should fix the vertically-stretched camera feed (#9) via the aspect-correct DOM video.
- Addresses #90 (LocAR 0.2.0 upgrade).

## Needs device verification
Camera + GPS required (can't verify headless). On a phone, run `apps/geolocation-demo` and confirm: feed is not stretched, color is natural, anchors align with GPS. Watch for canvas/video z-index stacking.