### PR TITLE
feat(vision): ONNX instance segmentation (YOLO-seg masks)

### DIFF
--- a/.changeset/vision-segmentation.md
+++ b/.changeset/vision-segmentation.md
@@ -1,0 +1,7 @@
+---
+"@omnidotdev/rdk": minor
+---
+
+Add ONNX instance segmentation to the vision module. A new `yoloseg` decoder assembles per-instance masks from a YOLOv8/v11-seg model (detection `[1, 4+C+M, A]` + prototype `[1, M, H, W]` outputs) as `sigmoid(coeffs · prototypes)`, thresholded and cropped to each box. Results arrive on `VisionFrame.masks` as `SegmentationMask[]` (label, confidence, source-space bbox, and a cropped alpha mask), with mask buffers transferred zero-copy from the worker.
+
+The decoder interface now returns `{ objects?, masks? }`, and a `yoloSeg()` model preset + `SegmentationMask` type are exported. The demo gains a "Segment" mode.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > [!IMPORTANT]
 > **Project Status:** 🚧 This project is **brand new**.
-> Currently, fiducial marker-based AR via [AR.js](https://github.com/ar-js-org/ar.js), location-based AR via [LocAR.js](https://github.com/ar-js-org/locar.js), WebXR via [`@react-three/xr`](https://github.com/pmndrs/xr), and ML vision (hand/face/pose tracking, gestures, and ONNX object detection via [MediaPipe](https://ai.google.dev/edge/mediapipe) + [ONNX Runtime Web](https://onnxruntime.ai)) are working (see [`apps/`](./apps/) for demos), though they are **experimental**. Contributions (PRs, [Omni organization sponsorship](https://github.com/sponsors/omnidotdev)) appreciated.
+> Currently, fiducial marker-based AR via [AR.js](https://github.com/ar-js-org/ar.js), location-based AR via [LocAR.js](https://github.com/ar-js-org/locar.js), WebXR via [`@react-three/xr`](https://github.com/pmndrs/xr), and ML vision (hand/face/pose tracking, gestures, and ONNX object detection + instance segmentation via [MediaPipe](https://ai.google.dev/edge/mediapipe) + [ONNX Runtime Web](https://onnxruntime.ai)) are working (see [`apps/`](./apps/) for demos), though they are **experimental**. Contributions (PRs, [Omni organization sponsorship](https://github.com/sponsors/omnidotdev)) appreciated.
 
 ## Overview
 
@@ -28,6 +28,7 @@ RDK unifies multiple spatial and XR technologies, such as AR.js for marker-based
 | **Body/Pose Tracking**               | ⚗️ Experimental | [MediaPipe Pose Landmarker](https://ai.google.dev/edge/mediapipe)                                    | ✅      | ✅             | Real-time skeletal tracking via MediaPipe Tasks Vision.                                    |
 | **Hand Tracking**                    | ⚗️ Experimental | [MediaPipe Hand Landmarker](https://ai.google.dev/edge/mediapipe)                                    | ✅      | ✅             | Includes built-in gesture detection (fist, peace, thumbs up, etc.).                       |
 | **Object Detection (2D)**            | ⚗️ Experimental | [ONNX Runtime Web](https://onnxruntime.ai/docs/tutorials/web) (YOLO / RF-DETR)                       | ✅      | ✅             | Pluggable decoders; inference runs in a Web Worker. Bring your own model via presets.     |
+| **Instance Segmentation**            | ⚗️ Experimental | [ONNX Runtime Web](https://onnxruntime.ai/docs/tutorials/web) (YOLO-seg)                             | ✅      | ✅             | Per-instance masks + labels in a Web Worker; mask buffers transferred zero-copy.          |
 | **Plane/Surface Detection**          | 🧭 Planned      | [WebXR Hit Test API](https://immersive-web.github.io/hit-test)/ar.js (limited)                       | N/A     | N/A            | Enables AR object placement on flat surfaces.                                             |
 | **Depth Sensing/Environment Mesh**   | 🧭 Planned      | [WebXR Depth Sensing API](https://immersive-web.github.io/depth-sensing)                             | N/A     | N/A            | Provides per-pixel depth; early spec.                                                     |
 | **SLAM/Visual Positioning (VPS)**    | 🧭 Planned      | Custom                                                                                               | N/A     | N/A            | Requires world map data; long-term goal.                                                  |

--- a/apps/vision-demo/src/App.tsx
+++ b/apps/vision-demo/src/App.tsx
@@ -4,6 +4,7 @@ import {
   ModeSelector,
   ObjectMode,
   PoseMode,
+  SegmentMode,
 } from "components";
 import { useState } from "react";
 
@@ -33,6 +34,7 @@ const App = () => {
         {mode === "faces" && <FaceMode tasks={MODE_TASKS.faces} />}
         {mode === "poses" && <PoseMode tasks={MODE_TASKS.poses} />}
         {mode === "objects" && <ObjectMode />}
+        {mode === "segment" && <SegmentMode />}
       </div>
 
       <ModeSelector mode={mode} onModeChange={setMode} />

--- a/apps/vision-demo/src/components/ModeSelector.tsx
+++ b/apps/vision-demo/src/components/ModeSelector.tsx
@@ -1,4 +1,4 @@
-export type Mode = "hands" | "faces" | "poses" | "objects";
+export type Mode = "hands" | "faces" | "poses" | "objects" | "segment";
 
 type ModeSelectorProps = {
   mode: Mode;
@@ -28,6 +28,7 @@ const MODES: { key: Mode; label: string }[] = [
   { key: "faces", label: "Faces" },
   { key: "poses", label: "Poses" },
   { key: "objects", label: "Objects" },
+  { key: "segment", label: "Segment" },
 ];
 
 const ModeSelector = ({ mode, onModeChange }: ModeSelectorProps) => (

--- a/apps/vision-demo/src/components/SegmentMode.tsx
+++ b/apps/vision-demo/src/components/SegmentMode.tsx
@@ -1,0 +1,73 @@
+import {
+  CameraBackground,
+  VisionSession,
+  yoloSeg,
+} from "@omnidotdev/rdk/vision";
+import { Canvas } from "@react-three/fiber";
+import { useCallback, useMemo, useState } from "react";
+
+import ErrorBanner from "./ErrorBanner";
+import SegmentationOverlay from "./SegmentationOverlay";
+
+import type { VisionSessionOptions } from "@omnidotdev/rdk/vision";
+
+// YOLOv8n-seg export (detection [1,116,8400] + prototypes [1,32,160,160]);
+// mask assembly + NMS run in the RDK decoder.
+const MODEL_URL =
+  "https://raw.githubusercontent.com/Hyuto/yolov8-seg-onnxruntime-web/master/public/model/yolov8n-seg.onnx";
+
+/**
+ * ONNX instance-segmentation mode: rear camera -> ONNX Runtime Web (YOLOv8n-seg)
+ * in a worker -> per-instance masks. Exercises the segmentation decoder path.
+ */
+const SegmentMode = () => {
+  const [video, setVideo] = useState<HTMLVideoElement | null>(null);
+  const [error, setError] = useState("");
+
+  const handleError = useCallback((err: Error) => setError(err.message), []);
+  const handleReady = useCallback((v: HTMLVideoElement) => setVideo(v), []);
+
+  const options: VisionSessionOptions = useMemo(
+    () => ({
+      provider: "onnx",
+      tasks: ["objects"],
+      minConfidence: 0.4,
+      maxResults: 10,
+      // This export has a fixed 640 input; inputSize is only tunable on a
+      // dynamic-shape export.
+      onnx: { models: [yoloSeg(MODEL_URL)] },
+      videoElement: video ?? undefined,
+    }),
+    [video],
+  );
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <CameraBackground
+        constraints={{
+          facingMode: "environment",
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+          frameRate: { ideal: 30 },
+        }}
+        mirrored={false}
+        onReady={handleReady}
+        onError={handleError}
+      />
+
+      {video && (
+        <Canvas
+          style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+        >
+          <VisionSession options={options} onError={handleError} />
+        </Canvas>
+      )}
+
+      <SegmentationOverlay />
+
+      {error && <ErrorBanner message={error} />}
+    </div>
+  );
+};
+
+export default SegmentMode;

--- a/apps/vision-demo/src/components/SegmentationOverlay.tsx
+++ b/apps/vision-demo/src/components/SegmentationOverlay.tsx
@@ -1,0 +1,111 @@
+import { useVisionFrame } from "@omnidotdev/rdk/vision";
+import { useEffect, useRef } from "react";
+
+// Per-instance colors as [r, g, b]
+const COLORS: [number, number, number][] = [
+  [78, 205, 196],
+  [255, 107, 107],
+  [69, 183, 209],
+  [255, 217, 61],
+  [160, 108, 213],
+  [255, 159, 67],
+];
+
+const MASK_ALPHA = 140;
+
+type SegmentationOverlayProps = {
+  /** Mirror masks horizontally to match a mirrored (selfie) preview */
+  mirror?: boolean;
+};
+
+/**
+ * Draws per-instance segmentation masks (colored, translucent) + labels on a 2D
+ * canvas over the camera feed, undoing the `object-fit: cover` crop so masks
+ * line up with the video.
+ */
+const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frame = useVisionFrame();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const cw = canvas.clientWidth;
+    const ch = canvas.clientHeight;
+    canvas.width = cw * dpr;
+    canvas.height = ch * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cw, ch);
+
+    const masks = frame?.masks;
+    if (!frame || !masks || masks.length === 0) return;
+    const { width: fw, height: fh } = frame.frameSize;
+    if (!fw || !fh) return;
+
+    const containerAspect = cw / ch;
+    const frameAspect = fw / fh;
+    const rx =
+      frameAspect > containerAspect ? frameAspect / containerAspect : 1;
+    const ry =
+      frameAspect > containerAspect ? 1 : containerAspect / frameAspect;
+
+    ctx.font = "600 14px system-ui, sans-serif";
+    ctx.textBaseline = "top";
+    ctx.imageSmoothingEnabled = true;
+
+    masks.forEach((m, i) => {
+      const [r, g, b] = COLORS[i % COLORS.length];
+
+      // Paint the mask into a small offscreen canvas, then scale into the box
+      const maskCanvas = new OffscreenCanvas(m.maskWidth, m.maskHeight);
+      const maskCtx = maskCanvas.getContext("2d");
+      if (!maskCtx) return;
+      const img = maskCtx.createImageData(m.maskWidth, m.maskHeight);
+      for (let p = 0; p < m.mask.length; p++) {
+        if (m.mask[p]) {
+          img.data[p * 4] = r;
+          img.data[p * 4 + 1] = g;
+          img.data[p * 4 + 2] = b;
+          img.data[p * 4 + 3] = MASK_ALPHA;
+        }
+      }
+      maskCtx.putImageData(img, 0, 0);
+
+      const nw = (m.bbox.width / fw) * rx;
+      const nh = (m.bbox.height / fh) * ry;
+      let u = 0.5 + (m.bbox.x / fw - 0.5) * rx;
+      const v = 0.5 + (m.bbox.y / fh - 0.5) * ry;
+      if (mirror) u = 1 - u - nw;
+
+      const left = u * cw;
+      const top = v * ch;
+      ctx.drawImage(maskCanvas, left, top, nw * cw, nh * ch);
+
+      const label = `${m.label} ${Math.round(m.confidence * 100)}%`;
+      const labelTop = Math.max(0, top - 18);
+      ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+      ctx.fillRect(left, labelTop, ctx.measureText(label).width + 8, 18);
+      ctx.fillStyle = "#000";
+      ctx.fillText(label, left + 4, labelTop + 2);
+    });
+  }, [frame, mirror]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+      }}
+    />
+  );
+};
+
+export default SegmentationOverlay;

--- a/apps/vision-demo/src/components/SegmentationOverlay.tsx
+++ b/apps/vision-demo/src/components/SegmentationOverlay.tsx
@@ -25,6 +25,8 @@ type SegmentationOverlayProps = {
  */
 const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Reused across masks/frames to avoid per-instance canvas allocation
+  const scratchRef = useRef<OffscreenCanvas | null>(null);
   const frame = useVisionFrame();
 
   useEffect(() => {
@@ -32,6 +34,11 @@ const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
+
+    if (!scratchRef.current) scratchRef.current = new OffscreenCanvas(1, 1);
+    const scratch = scratchRef.current;
+    const scratchCtx = scratch.getContext("2d");
+    if (!scratchCtx) return;
 
     const dpr = window.devicePixelRatio || 1;
     const cw = canvas.clientWidth;
@@ -60,11 +67,10 @@ const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
     masks.forEach((m, i) => {
       const [r, g, b] = COLORS[i % COLORS.length];
 
-      // Paint the mask into a small offscreen canvas, then scale into the box
-      const maskCanvas = new OffscreenCanvas(m.maskWidth, m.maskHeight);
-      const maskCtx = maskCanvas.getContext("2d");
-      if (!maskCtx) return;
-      const img = maskCtx.createImageData(m.maskWidth, m.maskHeight);
+      // Paint the mask into the reused scratch canvas, then scale into the box
+      scratch.width = m.maskWidth;
+      scratch.height = m.maskHeight;
+      const img = scratchCtx.createImageData(m.maskWidth, m.maskHeight);
       for (let p = 0; p < m.mask.length; p++) {
         if (m.mask[p]) {
           img.data[p * 4] = r;
@@ -73,7 +79,7 @@ const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
           img.data[p * 4 + 3] = MASK_ALPHA;
         }
       }
-      maskCtx.putImageData(img, 0, 0);
+      scratchCtx.putImageData(img, 0, 0);
 
       const nw = (m.bbox.width / fw) * rx;
       const nh = (m.bbox.height / fh) * ry;
@@ -83,7 +89,7 @@ const SegmentationOverlay = ({ mirror = false }: SegmentationOverlayProps) => {
 
       const left = u * cw;
       const top = v * ch;
-      ctx.drawImage(maskCanvas, left, top, nw * cw, nh * ch);
+      ctx.drawImage(scratch, left, top, nw * cw, nh * ch);
 
       const label = `${m.label} ${Math.round(m.confidence * 100)}%`;
       const labelTop = Math.max(0, top - 18);

--- a/apps/vision-demo/src/components/index.ts
+++ b/apps/vision-demo/src/components/index.ts
@@ -3,5 +3,6 @@ export { default as HandMode } from "./HandMode";
 export { default as ModeSelector } from "./ModeSelector";
 export { default as ObjectMode } from "./ObjectMode";
 export { default as PoseMode } from "./PoseMode";
+export { default as SegmentMode } from "./SegmentMode";
 
 export type { Mode } from "./ModeSelector";

--- a/packages/rdk/src/vision/index.ts
+++ b/packages/rdk/src/vision/index.ts
@@ -10,7 +10,7 @@ export {
 } from "./gestures";
 export { default as HandTracker } from "./HandTracker";
 export { landmarksCentroid, landmarkToWorld } from "./landmarkMapping";
-export { COCO_LABELS, rfDetr, yolo } from "./presets";
+export { COCO_LABELS, rfDetr, yolo, yoloSeg } from "./presets";
 export { default as useVisionBackend } from "./useVisionBackend";
 export { default as useVisionFrame } from "./useVisionFrame";
 export { default as VisionAnchor } from "./VisionAnchor";
@@ -30,6 +30,7 @@ export type {
   ObjectDetection,
   ONNXDecoderName,
   ONNXModelConfig,
+  SegmentationMask,
   VisionFrame,
   VisionLandmark,
   VisionProgress,

--- a/packages/rdk/src/vision/presets.test.ts
+++ b/packages/rdk/src/vision/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { COCO_LABELS, rfDetr, yolo } from "./presets";
+import { COCO_LABELS, rfDetr, yolo, yoloSeg } from "./presets";
 
 describe("presets", () => {
   it("yolo() wires the yolo decoder + COCO labels + path", () => {
@@ -16,6 +16,14 @@ describe("presets", () => {
     const config = rfDetr("/models/rf-detr.onnx");
     expect(config.decoder).toBe("rfdetr");
     expect(config.name).toBe("rf-detr");
+  });
+
+  it("yoloSeg() wires the yoloseg decoder", () => {
+    const config = yoloSeg("/models/yolo11n-seg.onnx");
+    expect(config.decoder).toBe("yoloseg");
+    expect(config.name).toBe("yolo-seg");
+    expect(config.inputSize).toBe(640);
+    expect(config.labels).toHaveLength(80);
   });
 
   it("allows overrides but pins path + decoder", () => {

--- a/packages/rdk/src/vision/presets.ts
+++ b/packages/rdk/src/vision/presets.ts
@@ -129,3 +129,23 @@ export const rfDetr = (
   path,
   decoder: "rfdetr",
 });
+
+/**
+ * Build a config for a YOLOv8/v11-**seg** instance-segmentation model. Expects a
+ * `[1, 4 + numClasses + M, numAnchors]` detection output and a
+ * `[1, M, protoH, protoW]` prototype output; produces per-instance masks.
+ *
+ * @param path URL or same-origin path to the exported `.onnx` weights
+ *   (e.g. from `yolo export format=onnx` on a `-seg` model). Weights are not bundled.
+ */
+export const yoloSeg = (
+  path: string,
+  overrides: PresetOverrides = {},
+): ONNXModelConfig => ({
+  name: "yolo-seg",
+  inputSize: 640,
+  labels: [...COCO_LABELS],
+  ...overrides,
+  path,
+  decoder: "yoloseg",
+});

--- a/packages/rdk/src/vision/providers/onnxProvider.ts
+++ b/packages/rdk/src/vision/providers/onnxProvider.ts
@@ -260,6 +260,7 @@ class ONNXProvider implements VisionProvider {
       faces: [],
       poses: [],
       objects,
+      masks: result.masks.length > 0 ? result.masks : undefined,
       timestamp: result.timestamp,
       frameSize: result.frameSize,
       processingTime: result.processingTime,

--- a/packages/rdk/src/vision/types.ts
+++ b/packages/rdk/src/vision/types.ts
@@ -23,12 +23,31 @@ export type ObjectDetection = {
   };
 };
 
+/** A per-instance segmentation mask, cropped to its bounding box */
+export type SegmentationMask = {
+  label: string;
+  confidence: number;
+  /** Bounding box in source pixel coordinates */
+  bbox: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  /** Row-major alpha values (0-255) covering the bbox, sized maskWidth x maskHeight */
+  mask: Uint8Array;
+  maskWidth: number;
+  maskHeight: number;
+};
+
 /** A single frame of vision detection results */
 export type VisionFrame = {
   hands: LandmarkDetection[];
   faces: LandmarkDetection[];
   poses: LandmarkDetection[];
   objects: ObjectDetection[];
+  /** Per-instance segmentation masks (present when a segmentation model runs) */
+  masks?: SegmentationMask[];
   timestamp: number;
   frameSize: { width: number; height: number };
   processingTime?: number;
@@ -39,7 +58,7 @@ export type VisionFrame = {
 export type VisionTask = "hands" | "faces" | "poses" | "objects";
 
 /** Identifier of a registered ONNX output decoder */
-export type ONNXDecoderName = "yolo" | "rfdetr";
+export type ONNXDecoderName = "yolo" | "rfdetr" | "yoloseg";
 
 /** ONNX model configuration */
 export type ONNXModelConfig = {

--- a/packages/rdk/src/vision/worker/decoders/decoders.test.ts
+++ b/packages/rdk/src/vision/worker/decoders/decoders.test.ts
@@ -124,7 +124,7 @@ describe("yoloDecoder", () => {
       0.1, // class 1
     ];
 
-    const out = yoloDecoder.decode(
+    const { objects: out = [] } = yoloDecoder.decode(
       { output0: { data, dims: [1, 6, 3] } },
       identityCtx({ labels: ["a", "b"] }),
     );
@@ -157,7 +157,7 @@ describe("yoloDecoder", () => {
       0.0,
       0.0, // class 1
     ];
-    const out = yoloDecoder.decode(
+    const { objects: out = [] } = yoloDecoder.decode(
       { output0: { data, dims: [1, 6, 3] } },
       identityCtx({ labels: ["a", "b"], maxResults: 2 }),
     );
@@ -174,7 +174,7 @@ describe("rfDetrDecoder", () => {
     const boxes = [0.5, 0.5, 0.1, 0.1, 0.5, 0.5, 0.2, 0.2];
     const logits = [-5, 2, -5, -5, -5, -5];
 
-    const out = rfDetrDecoder.decode(
+    const { objects: out = [] } = rfDetrDecoder.decode(
       {
         boxes: { data: boxes, dims: [1, 2, 4] },
         logits: { data: logits, dims: [1, 2, 3] },
@@ -192,7 +192,7 @@ describe("rfDetrDecoder", () => {
   it("identifies boxes/logits tensors regardless of key order", () => {
     const boxes = [0.5, 0.5, 0.1, 0.1];
     const logits = [-5, 3, -5];
-    const out = rfDetrDecoder.decode(
+    const { objects: out = [] } = rfDetrDecoder.decode(
       {
         // logits first, boxes second: split must key off dims, not order
         pred_logits: { data: logits, dims: [1, 1, 3] },

--- a/packages/rdk/src/vision/worker/decoders/index.ts
+++ b/packages/rdk/src/vision/worker/decoders/index.ts
@@ -1,5 +1,6 @@
 import { rfDetrDecoder } from "./rfDetr";
 import { yoloDecoder } from "./yolo";
+import { yoloSegDecoder } from "./yoloSeg";
 
 import type { ONNXDecoderName } from "../../types";
 import type { ONNXDecoder } from "./types";
@@ -8,10 +9,16 @@ import type { ONNXDecoder } from "./types";
 const DECODERS: Record<ONNXDecoderName, ONNXDecoder> = {
   yolo: yoloDecoder,
   rfdetr: rfDetrDecoder,
+  yoloseg: yoloSegDecoder,
 };
 
 /** Resolve a decoder by name, defaulting to YOLO */
 export const getDecoder = (name: ONNXDecoderName = "yolo"): ONNXDecoder =>
   DECODERS[name] ?? yoloDecoder;
 
-export type { DecodeContext, ONNXDecoder, TensorLike } from "./types";
+export type {
+  DecodeContext,
+  DecodeResult,
+  ONNXDecoder,
+  TensorLike,
+} from "./types";

--- a/packages/rdk/src/vision/worker/decoders/rfDetr.ts
+++ b/packages/rdk/src/vision/worker/decoders/rfDetr.ts
@@ -1,7 +1,12 @@
 import { letterboxToSource } from "./nms";
 
 import type { ObjectDetection } from "../../types";
-import type { DecodeContext, ONNXDecoder, TensorLike } from "./types";
+import type {
+  DecodeContext,
+  DecodeResult,
+  ONNXDecoder,
+  TensorLike,
+} from "./types";
 
 const sigmoid = (x: number): number => 1 / (1 + Math.exp(-x));
 
@@ -34,7 +39,7 @@ export const rfDetrDecoder: ONNXDecoder = {
   decode(
     outputs: Record<string, TensorLike>,
     ctx: DecodeContext,
-  ): ObjectDetection[] {
+  ): DecodeResult {
     const { boxes, logits } = splitOutputs(outputs);
 
     const numQueries = boxes.dims[1];
@@ -81,8 +86,10 @@ export const rfDetrDecoder: ONNXDecoder = {
     }
 
     // Set prediction: no NMS, just rank and cap
-    return detections
+    const objects = detections
       .sort((a, b) => b.confidence - a.confidence)
       .slice(0, ctx.maxResults);
+
+    return { objects };
   },
 };

--- a/packages/rdk/src/vision/worker/decoders/types.ts
+++ b/packages/rdk/src/vision/worker/decoders/types.ts
@@ -1,4 +1,4 @@
-import type { ObjectDetection } from "../../types";
+import type { ObjectDetection, SegmentationMask } from "../../types";
 
 /**
  * Minimal structural view of an onnxruntime-web tensor. Decoders depend on this
@@ -32,14 +32,17 @@ export type DecodeContext = {
   maxResults: number;
 };
 
+/** Output of a decoder: detections and/or per-instance segmentation masks */
+export type DecodeResult = {
+  objects?: ObjectDetection[];
+  masks?: SegmentationMask[];
+};
+
 /**
- * Interprets a model's raw output tensors into detections in source pixel
+ * Interprets a model's raw output tensors into detections/masks in source pixel
  * coordinates. Register concrete decoders by {@link import("../../types").ONNXDecoderName}.
  */
 export type ONNXDecoder = {
   readonly name: string;
-  decode(
-    outputs: Record<string, TensorLike>,
-    ctx: DecodeContext,
-  ): ObjectDetection[];
+  decode(outputs: Record<string, TensorLike>, ctx: DecodeContext): DecodeResult;
 };

--- a/packages/rdk/src/vision/worker/decoders/yolo.ts
+++ b/packages/rdk/src/vision/worker/decoders/yolo.ts
@@ -1,7 +1,12 @@
 import { letterboxToSource, nms } from "./nms";
 
 import type { ObjectDetection } from "../../types";
-import type { DecodeContext, ONNXDecoder, TensorLike } from "./types";
+import type {
+  DecodeContext,
+  DecodeResult,
+  ONNXDecoder,
+  TensorLike,
+} from "./types";
 
 /** IoU threshold for YOLO non-maximum suppression */
 const YOLO_IOU_THRESHOLD = 0.45;
@@ -27,7 +32,7 @@ export const yoloDecoder: ONNXDecoder = {
   decode(
     outputs: Record<string, TensorLike>,
     ctx: DecodeContext,
-  ): ObjectDetection[] {
+  ): DecodeResult {
     const tensor = firstTensor(outputs);
     const { dims, data } = tensor;
 
@@ -81,8 +86,10 @@ export const yoloDecoder: ONNXDecoder = {
       });
     }
 
-    return nms(detections, YOLO_IOU_THRESHOLD)
+    const objects = nms(detections, YOLO_IOU_THRESHOLD)
       .sort((a, b) => b.confidence - a.confidence)
       .slice(0, ctx.maxResults);
+
+    return { objects };
   },
 };

--- a/packages/rdk/src/vision/worker/decoders/yoloSeg.test.ts
+++ b/packages/rdk/src/vision/worker/decoders/yoloSeg.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { yoloSegDecoder } from "./yoloSeg";
+
+import type { DecodeContext } from "./types";
+
+// Identity letterbox with a tiny 8px input and 4x4 prototypes (protoScale 0.5)
+const ctx = (overrides: Partial<DecodeContext> = {}): DecodeContext => ({
+  inputSize: 8,
+  sourceWidth: 8,
+  sourceHeight: 8,
+  scale: 1,
+  padX: 0,
+  padY: 0,
+  labels: ["obj"],
+  minConfidence: 0.5,
+  maxResults: 10,
+  ...overrides,
+});
+
+describe("yoloSegDecoder", () => {
+  it("assembles a thresholded mask from coeffs . prototypes", () => {
+    // det [1, 7, 1]: 4 box + 1 class + 2 mask coeffs, 1 anchor
+    // box (cx=4,cy=4,w=8,h=8) covers the full 8px input -> full 4x4 proto crop
+    // class score 0.9; coeffs = [1, 0] so mask = sigmoid(proto0)
+    const det = [4, 4, 8, 8, 0.9, 1, 0];
+
+    // proto [1, 2, 4, 4]; proto0 positive only in the top-left 2x2, proto1 zeros
+    const proto0 = [
+      10,
+      10,
+      -10,
+      -10, //
+      10,
+      10,
+      -10,
+      -10, //
+      -10,
+      -10,
+      -10,
+      -10, //
+      -10,
+      -10,
+      -10,
+      -10,
+    ];
+    const proto1 = new Array(16).fill(0);
+    const proto = [...proto0, ...proto1];
+
+    const { masks, objects } = yoloSegDecoder.decode(
+      {
+        output0: { data: det, dims: [1, 7, 1] },
+        output1: { data: proto, dims: [1, 2, 4, 4] },
+      },
+      ctx(),
+    );
+
+    expect(masks).toHaveLength(1);
+    const m = masks?.[0];
+    expect(m?.label).toBe("obj");
+    expect(m?.confidence).toBeCloseTo(0.9, 6);
+    expect(m?.bbox).toEqual({ x: 0, y: 0, width: 8, height: 8 });
+    expect(m?.maskWidth).toBe(4);
+    expect(m?.maskHeight).toBe(4);
+    expect(Array.from(m?.mask ?? [])).toEqual([
+      255,
+      255,
+      0,
+      0, //
+      255,
+      255,
+      0,
+      0, //
+      0,
+      0,
+      0,
+      0, //
+      0,
+      0,
+      0,
+      0,
+    ]);
+
+    // objects mirror the detections (box + label) for convenience
+    expect(objects).toHaveLength(1);
+    expect(objects?.[0].bbox).toEqual({ x: 0, y: 0, width: 8, height: 8 });
+  });
+
+  it("drops detections below the confidence threshold", () => {
+    const det = [4, 4, 8, 8, 0.3, 1, 0];
+    const proto = new Array(32).fill(0);
+    const { masks } = yoloSegDecoder.decode(
+      {
+        output0: { data: det, dims: [1, 7, 1] },
+        output1: { data: proto, dims: [1, 2, 4, 4] },
+      },
+      ctx({ minConfidence: 0.5 }),
+    );
+    expect(masks).toHaveLength(0);
+  });
+
+  it("crops the mask to the detection's box", () => {
+    // box covers only the left half of the input (x 0..4) -> proto x 0..2
+    const det = [2, 4, 4, 8, 0.9, 1, 0];
+    const proto0 = new Array(16).fill(10); // all foreground
+    const proto = [...proto0, ...new Array(16).fill(0)];
+    const { masks } = yoloSegDecoder.decode(
+      {
+        output0: { data: det, dims: [1, 7, 1] },
+        output1: { data: proto, dims: [1, 2, 4, 4] },
+      },
+      ctx(),
+    );
+    expect(masks?.[0].maskWidth).toBe(2);
+    expect(masks?.[0].maskHeight).toBe(4);
+    expect(masks?.[0].bbox).toEqual({ x: 0, y: 0, width: 4, height: 8 });
+  });
+});

--- a/packages/rdk/src/vision/worker/decoders/yoloSeg.test.ts
+++ b/packages/rdk/src/vision/worker/decoders/yoloSeg.test.ts
@@ -115,4 +115,38 @@ describe("yoloSegDecoder", () => {
     expect(masks?.[0].maskHeight).toBe(4);
     expect(masks?.[0].bbox).toEqual({ x: 0, y: 0, width: 4, height: 8 });
   });
+
+  it("clamps the mask crop to the frame at letterboxed edges", () => {
+    // Landscape 8x4 source into an 8px input -> padY 2 (top/bottom bars).
+    // A box extending above the frame clamps to y=0; the mask crop must exclude
+    // the padding rows so it stays aligned with the (clamped) returned bbox.
+    const paddedCtx: DecodeContext = {
+      inputSize: 8,
+      sourceWidth: 8,
+      sourceHeight: 4,
+      scale: 1,
+      padX: 0,
+      padY: 2,
+      labels: ["obj"],
+      minConfidence: 0.5,
+      maxResults: 10,
+    };
+    // box cx=4,cy=1,w=8,h=6 -> input y1=-2 (above frame) .. y2=4
+    const det = [4, 1, 8, 6, 0.9, 1, 0];
+    const proto = [...new Array(16).fill(10), ...new Array(16).fill(0)];
+
+    const { masks } = yoloSegDecoder.decode(
+      {
+        output0: { data: det, dims: [1, 7, 1] },
+        output1: { data: proto, dims: [1, 2, 4, 4] },
+      },
+      paddedCtx,
+    );
+
+    expect(masks?.[0].bbox).toEqual({ x: 0, y: 0, width: 8, height: 2 });
+    expect(masks?.[0].maskWidth).toBe(4);
+    // padding row excluded -> single content row, not 2
+    expect(masks?.[0].maskHeight).toBe(1);
+    expect(Array.from(masks?.[0].mask ?? [])).toEqual([255, 255, 255, 255]);
+  });
 });

--- a/packages/rdk/src/vision/worker/decoders/yoloSeg.ts
+++ b/packages/rdk/src/vision/worker/decoders/yoloSeg.ts
@@ -19,8 +19,6 @@ type Candidate = {
   label: string;
   confidence: number;
   bbox: { x: number; y: number; width: number; height: number };
-  /** Box in input-space (letterboxed) pixels, for cropping the prototype masks */
-  inputBox: [number, number, number, number];
   coeffs: number[];
 };
 
@@ -94,7 +92,6 @@ export const yoloSegDecoder: ONNXDecoder = {
         label: ctx.labels[bestClass] ?? String(bestClass),
         confidence: bestScore,
         bbox,
-        inputBox: [x1, y1, x2, y2],
         coeffs,
       });
     }
@@ -117,7 +114,14 @@ export const yoloSegDecoder: ONNXDecoder = {
     const sy = protoH / ctx.inputSize;
 
     const masks: SegmentationMask[] = kept.map((cand) => {
-      const [ix1, iy1, ix2, iy2] = cand.inputBox;
+      // Map the (frame-clamped) source bbox back into input space, then onto the
+      // prototype grid, so the mask crop matches the returned bbox exactly -
+      // including at frame edges where the raw box is clamped.
+      const { x, y, width, height } = cand.bbox;
+      const ix1 = x * ctx.scale + ctx.padX;
+      const iy1 = y * ctx.scale + ctx.padY;
+      const ix2 = (x + width) * ctx.scale + ctx.padX;
+      const iy2 = (y + height) * ctx.scale + ctx.padY;
       const px0 = Math.max(0, Math.floor(ix1 * sx));
       const py0 = Math.max(0, Math.floor(iy1 * sy));
       const px1 = Math.min(protoW, Math.ceil(ix2 * sx));

--- a/packages/rdk/src/vision/worker/decoders/yoloSeg.ts
+++ b/packages/rdk/src/vision/worker/decoders/yoloSeg.ts
@@ -1,0 +1,159 @@
+import { iou, letterboxToSource } from "./nms";
+
+import type { SegmentationMask } from "../../types";
+import type {
+  DecodeContext,
+  DecodeResult,
+  ONNXDecoder,
+  TensorLike,
+} from "./types";
+
+/** IoU threshold for YOLO-seg non-maximum suppression */
+const SEG_IOU_THRESHOLD = 0.45;
+/** Mask coefficient cutoff after sigmoid */
+const MASK_THRESHOLD = 0.5;
+
+const sigmoid = (x: number): number => 1 / (1 + Math.exp(-x));
+
+type Candidate = {
+  label: string;
+  confidence: number;
+  bbox: { x: number; y: number; width: number; height: number };
+  /** Box in input-space (letterboxed) pixels, for cropping the prototype masks */
+  inputBox: [number, number, number, number];
+  coeffs: number[];
+};
+
+/**
+ * Decoder for YOLOv8/v11-**seg** instance-segmentation heads.
+ *
+ * Two outputs: detection `[1, 4 + numClasses + M, numAnchors]` (box + class
+ * scores + M mask coefficients) and prototypes `[1, M, protoH, protoW]`. Each
+ * kept detection's mask is `sigmoid(coeffs . prototypes)`, thresholded and
+ * cropped to its box (prototypes live in the same letterboxed input space).
+ */
+export const yoloSegDecoder: ONNXDecoder = {
+  name: "yoloseg",
+
+  decode(
+    outputs: Record<string, TensorLike>,
+    ctx: DecodeContext,
+  ): DecodeResult {
+    const tensors = Object.values(outputs);
+    const proto = tensors.find((t) => t.dims.length === 4);
+    const det = tensors.find((t) => t.dims.length === 3);
+    if (!proto || !det) {
+      throw new Error(
+        "YOLO-seg decoder: expected a [1, C, A] detection tensor and a [1, M, H, W] prototype tensor",
+      );
+    }
+
+    const numCoeffs = proto.dims[1];
+    const protoH = proto.dims[2];
+    const protoW = proto.dims[3];
+    const channels = det.dims[1];
+    const anchors = det.dims[2];
+    const numClasses = channels - 4 - numCoeffs;
+    if (numClasses <= 0) {
+      throw new Error(`YOLO-seg decoder: bad channel count (${channels})`);
+    }
+
+    const data = det.data;
+    const candidates: Candidate[] = [];
+
+    for (let a = 0; a < anchors; a++) {
+      let bestScore = 0;
+      let bestClass = -1;
+      for (let c = 0; c < numClasses; c++) {
+        const score = data[(4 + c) * anchors + a];
+        if (score > bestScore) {
+          bestScore = score;
+          bestClass = c;
+        }
+      }
+      if (bestClass < 0 || bestScore < ctx.minConfidence) continue;
+
+      const cx = data[a];
+      const cy = data[anchors + a];
+      const w = data[2 * anchors + a];
+      const h = data[3 * anchors + a];
+      const x1 = cx - w / 2;
+      const y1 = cy - h / 2;
+      const x2 = cx + w / 2;
+      const y2 = cy + h / 2;
+
+      const bbox = letterboxToSource(x1, y1, x2, y2, ctx);
+      if (!bbox) continue;
+
+      const coeffs: number[] = [];
+      for (let k = 0; k < numCoeffs; k++) {
+        coeffs.push(data[(4 + numClasses + k) * anchors + a]);
+      }
+
+      candidates.push({
+        label: ctx.labels[bestClass] ?? String(bestClass),
+        confidence: bestScore,
+        bbox,
+        inputBox: [x1, y1, x2, y2],
+        coeffs,
+      });
+    }
+
+    // Greedy NMS, then cap
+    candidates.sort((a, b) => b.confidence - a.confidence);
+    const kept: Candidate[] = [];
+    for (const cand of candidates) {
+      const overlaps = kept.some(
+        (k) =>
+          k.label === cand.label && iou(k.bbox, cand.bbox) > SEG_IOU_THRESHOLD,
+      );
+      if (!overlaps) kept.push(cand);
+      if (kept.length >= ctx.maxResults) break;
+    }
+
+    const protoData = proto.data;
+    const plane = protoH * protoW;
+    const sx = protoW / ctx.inputSize;
+    const sy = protoH / ctx.inputSize;
+
+    const masks: SegmentationMask[] = kept.map((cand) => {
+      const [ix1, iy1, ix2, iy2] = cand.inputBox;
+      const px0 = Math.max(0, Math.floor(ix1 * sx));
+      const py0 = Math.max(0, Math.floor(iy1 * sy));
+      const px1 = Math.min(protoW, Math.ceil(ix2 * sx));
+      const py1 = Math.min(protoH, Math.ceil(iy2 * sy));
+      const cw = Math.max(1, px1 - px0);
+      const ch = Math.max(1, py1 - py0);
+      const mask = new Uint8Array(cw * ch);
+
+      for (let py = py0; py < py1; py++) {
+        for (let px = px0; px < px1; px++) {
+          let sum = 0;
+          for (let k = 0; k < numCoeffs; k++) {
+            sum += cand.coeffs[k] * protoData[k * plane + py * protoW + px];
+          }
+          if (sigmoid(sum) > MASK_THRESHOLD) {
+            mask[(py - py0) * cw + (px - px0)] = 255;
+          }
+        }
+      }
+
+      return {
+        label: cand.label,
+        confidence: cand.confidence,
+        bbox: cand.bbox,
+        mask,
+        maskWidth: cw,
+        maskHeight: ch,
+      };
+    });
+
+    const objects = kept.map((c) => ({
+      label: c.label,
+      confidence: c.confidence,
+      bbox: c.bbox,
+    }));
+
+    return { objects, masks };
+  },
+};

--- a/packages/rdk/src/vision/worker/onnxWorker.ts
+++ b/packages/rdk/src/vision/worker/onnxWorker.ts
@@ -5,8 +5,12 @@ import { getDecoder } from "./decoders";
 import { computeLetterbox, rgbaToNchw } from "./preprocess";
 
 import type { InferenceSession } from "onnxruntime-web";
-import type { ObjectDetection, ONNXModelConfig } from "../types";
-import type { DecodeContext, TensorLike } from "./decoders";
+import type {
+  ObjectDetection,
+  ONNXModelConfig,
+  SegmentationMask,
+} from "../types";
+import type { DecodeContext, DecodeResult, TensorLike } from "./decoders";
 import type {
   ONNXProcessOptions,
   ONNXWorkerRequest,
@@ -36,8 +40,12 @@ const loadOrt = (): Promise<OrtModule> => {
   return ortPromise;
 };
 
-const post = (message: ONNXWorkerResponse): void => {
-  self.postMessage(message);
+const post = (message: ONNXWorkerResponse, transfer?: Transferable[]): void => {
+  if (transfer && transfer.length > 0) {
+    self.postMessage(message, { transfer });
+  } else {
+    self.postMessage(message);
+  }
 };
 
 /** Preprocess, run one model, and decode its outputs to source-space boxes */
@@ -48,7 +56,7 @@ const runModel = async (
   sourceWidth: number,
   sourceHeight: number,
   options: ONNXProcessOptions,
-): Promise<ObjectDetection[]> => {
+): Promise<DecodeResult> => {
   const size = loaded.config.inputSize ?? DEFAULT_INPUT_SIZE;
   const { scale, padX, padY, drawWidth, drawHeight } = computeLetterbox(
     sourceWidth,
@@ -132,28 +140,36 @@ const handleMessage = async (event: MessageEvent): Promise<void> => {
         const started = performance.now();
 
         const detections: ObjectDetection[] = [];
+        const masks: SegmentationMask[] = [];
         for (const loaded of models.values()) {
-          detections.push(
-            ...(await runModel(
-              ort,
-              loaded,
-              imageBitmap,
-              sourceWidth,
-              sourceHeight,
-              options,
-            )),
+          const result = await runModel(
+            ort,
+            loaded,
+            imageBitmap,
+            sourceWidth,
+            sourceHeight,
+            options,
           );
+          if (result.objects) detections.push(...result.objects);
+          if (result.masks) masks.push(...result.masks);
         }
 
-        post({
-          type: "result",
-          result: {
-            detections,
-            frameSize: { width: sourceWidth, height: sourceHeight },
-            timestamp: Date.now(),
-            processingTime: performance.now() - started,
+        // Transfer mask buffers (zero-copy) instead of structured-cloning them
+        const transfer = masks.map((m) => m.mask.buffer);
+
+        post(
+          {
+            type: "result",
+            result: {
+              detections,
+              masks,
+              frameSize: { width: sourceWidth, height: sourceHeight },
+              timestamp: Date.now(),
+              processingTime: performance.now() - started,
+            },
           },
-        });
+          transfer,
+        );
       } catch (error) {
         post({
           type: "error",

--- a/packages/rdk/src/vision/worker/types.ts
+++ b/packages/rdk/src/vision/worker/types.ts
@@ -1,4 +1,8 @@
-import type { ObjectDetection, ONNXModelConfig } from "../types";
+import type {
+  ObjectDetection,
+  ONNXModelConfig,
+  SegmentationMask,
+} from "../types";
 
 export type { VisionProgress } from "../types";
 
@@ -11,6 +15,7 @@ export type ONNXProcessOptions = {
 /** Result payload the ONNX worker produces for a processed frame */
 export type ONNXWorkerResult = {
   detections: ObjectDetection[];
+  masks: SegmentationMask[];
   frameSize: { width: number; height: number };
   timestamp: number;
   processingTime?: number;


### PR DESCRIPTION
Adds real-time **instance segmentation** to the vision module, extending the existing pluggable ONNX decoder architecture (no structural change beyond generalizing the decoder result).

## What changed
- **`yoloSeg` decoder** (`worker/decoders/yoloSeg.ts`): parses a YOLOv8/v11-seg model (detection `[1, 4+C+M, A]` + prototype `[1, M, H, W]`), runs NMS, and assembles each instance's mask as `sigmoid(coeffs · prototypes)`, thresholded and cropped to its box. Adapts to the model's actual prototype/input dims. Unit-tested (mask math, crop, confidence filter).
- **Generalized decoder result**: `ONNXDecoder.decode` now returns `{ objects?, masks? }`; `yolo`/`rfDetr` updated to `{ objects }`. Single runtime caller (the worker); no consumer breaks.
- **Masks on `VisionFrame.masks`** as `SegmentationMask[]` (label, confidence, source-space bbox, cropped alpha mask). Mask buffers are **transferred zero-copy** from the worker.
- **`yoloSeg()` preset** + `SegmentationMask` export.
- **Demo**: a "Segment" mode (rear camera → YOLOv8n-seg → colored mask overlay).
- **Docs**: README feature table gains an Instance Segmentation row; intro blurb updated. Changeset (minor).

## Testing / verification
- 120 vitest tests pass (typecheck lib+demo, Biome, Knip, all 6 builds green).
- Verified the demo model loads and outputs `[1,116,8400]` + `[1,32,160,160]` (matches the decoder).
- **Bundle size held**: the ONNX worker asset stays ~6 KB (onnxruntime-web remains an external optional peer dep, incl. the worker chunk).
- Device-validated: masks render aligned to objects (camera required, can't verify headless).

## Notes
- Instance segmentation is heavier than detection; masks update at a few fps on-device while the preview stays smooth. Input size is tunable for perf **only** on a dynamic-shape export (the demo model is fixed at 640).
- An independent review flagged two cosmetic non-blockers (edge-clamp mask/box mismatch; per-frame OffscreenCanvas churn in the demo overlay) — safe to ship or follow up.