### PR TITLE
Add click, pointer over, and pointer out event handling to GeoLine and GeoPolygon

### DIFF
--- a/.changeset/geoline-geopolygon-pointer-events.md
+++ b/.changeset/geoline-geopolygon-pointer-events.md
@@ -1,0 +1,7 @@
+---
+"@omnidotdev/rdk": patch
+---
+
+feat(geolocation): add pointer event handlers to `GeoLine` and `GeoPolygon`
+
+Adds optional `onClick`, `onPointerOver`, and `onPointerOut` props to `GeoLine` and `GeoPolygon`, forwarded to the underlying R3F scene object. Handlers receive a `ThreeEvent<MouseEvent>` (click) or `ThreeEvent<PointerEvent>` (pointer over/out). When a handler is omitted the element stays non-interactive and is not registered for pointer raycasting, so existing scenes keep their current behavior and cost.

--- a/apps/geolocation-demo/src/App.tsx
+++ b/apps/geolocation-demo/src/App.tsx
@@ -135,11 +135,25 @@ const DemoScene = ({ base }: { base: LatLon }) => {
         <Landmark isAnimated type="monument" color="#8e44ad" scale={0.8} />
       </GeolocationAnchor>
 
-      <GeoLine coordinates={pathCoordinates} color="#ff4444" />
+      <GeoLine
+        coordinates={pathCoordinates}
+        color="#ff4444"
+        onClick={() => alert("Regular line clicked!")}
+      />
 
-      <GeoLine coordinates={dashedPathCoordinates} color="#ffaa00" isDashed />
+      <GeoLine
+        coordinates={dashedPathCoordinates}
+        color="#ffaa00"
+        isDashed
+        onClick={() => alert("Dashed line clicked!")}
+      />
 
-      <GeoPolygon coordinates={zoneCoordinates} color="#4488ff" opacity={0.5} />
+      <GeoPolygon
+        coordinates={zoneCoordinates}
+        color="#4488ff"
+        opacity={0.5}
+        onClick={() => alert("Polygon clicked!")}
+      />
     </>
   );
 };

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -54,9 +54,6 @@
           "level": "error"
         }
       },
-      "a11y": {
-        "noStaticElementInteractions": "warn"
-      },
       "nursery": {
         "useSortedClasses": {
           "fix": "safe",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -54,6 +54,9 @@
           "level": "error"
         }
       },
+      "a11y": {
+        "noStaticElementInteractions": "warn"
+      },
       "nursery": {
         "useSortedClasses": {
           "fix": "safe",

--- a/packages/rdk/src/geolocation/GeoLine.tsx
+++ b/packages/rdk/src/geolocation/GeoLine.tsx
@@ -15,6 +15,7 @@ import { LineMaterial } from "three/addons/lines/LineMaterial.js";
 
 import useGeolocationBackend from "./useGeolocationBackend";
 
+import type { ThreeEvent } from "@react-three/fiber";
 import type { LocAR } from "locar";
 import type { ColorRepresentation } from "three";
 
@@ -46,6 +47,21 @@ export interface GeoLineProps {
    * @default 1
    */
   gapSize?: number;
+  /**
+   * Click event handler
+   * @default empty function
+   */
+  onClick?: (e: ThreeEvent<Group>) => void;
+  /**
+   * Pointer out event handler
+   * @default empty function
+   */
+  onPointerOut?: (e: ThreeEvent<Group>) => void;
+  /**
+   * Pointer over event handler
+   * @default empty function
+   */
+  onPointerOver?: (e: ThreeEvent<Group>) => void;
   /**
    * Opacity
    * @default 1
@@ -126,6 +142,9 @@ const GeoLine = ({
   dashSize = 3,
   gapSize = 1,
   lineWidth = 1,
+  onClick = () => {},
+  onPointerOut = () => {},
+  onPointerOver = () => {},
   opacity = 1,
 }: GeoLineProps) => {
   const geo = useGeolocationBackend();
@@ -220,7 +239,13 @@ const GeoLine = ({
   ]);
 
   return createPortal(
-    <group>{line && <primitive object={line} />}</group>,
+    <group
+      onClick={onClick}
+      onPointerOut={onPointerOut}
+      onPointerOver={onPointerOver}
+    >
+      {line && <primitive object={line} />}
+    </group>,
     anchor,
   );
 };

--- a/packages/rdk/src/geolocation/GeoLine.tsx
+++ b/packages/rdk/src/geolocation/GeoLine.tsx
@@ -48,20 +48,17 @@ export interface GeoLineProps {
    */
   gapSize?: number;
   /**
-   * Click event handler
-   * @default empty function
+   * Click event handler. When omitted, the line is not registered for pointer raycasting.
    */
-  onClick?: (e: ThreeEvent<Group>) => void;
+  onClick?: (e: ThreeEvent<MouseEvent>) => void;
   /**
-   * Pointer out event handler
-   * @default empty function
+   * Pointer out event handler. When omitted, the line is not registered for pointer raycasting.
    */
-  onPointerOut?: (e: ThreeEvent<Group>) => void;
+  onPointerOut?: (e: ThreeEvent<PointerEvent>) => void;
   /**
-   * Pointer over event handler
-   * @default empty function
+   * Pointer over event handler. When omitted, the line is not registered for pointer raycasting.
    */
-  onPointerOver?: (e: ThreeEvent<Group>) => void;
+  onPointerOver?: (e: ThreeEvent<PointerEvent>) => void;
   /**
    * Opacity
    * @default 1
@@ -142,9 +139,9 @@ const GeoLine = ({
   dashSize = 3,
   gapSize = 1,
   lineWidth = 1,
-  onClick = () => {},
-  onPointerOut = () => {},
-  onPointerOver = () => {},
+  onClick,
+  onPointerOut,
+  onPointerOver,
   opacity = 1,
 }: GeoLineProps) => {
   const geo = useGeolocationBackend();
@@ -239,6 +236,7 @@ const GeoLine = ({
   ]);
 
   return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: <group> is an R3F WebGL scene object, not a DOM element; these are three.js raycast events with no a11y semantics
     <group
       onClick={onClick}
       onPointerOut={onPointerOut}

--- a/packages/rdk/src/geolocation/GeoPolygon.tsx
+++ b/packages/rdk/src/geolocation/GeoPolygon.tsx
@@ -12,8 +12,9 @@ import {
 
 import useGeolocationBackend from "./useGeolocationBackend";
 
+import type { ThreeEvent } from "@react-three/fiber";
 import type { LocAR } from "locar";
-import type { Side } from "three";
+import type { Mesh, Side } from "three";
 
 export interface GeoPolygonProps {
   /** Outer ring coordinates. GeoJSON-style: [lon, lat, elevation?] */
@@ -38,6 +39,21 @@ export interface GeoPolygonProps {
    */
   isWireframe?: boolean;
   /**
+   * Click event handler
+   * @default empty function
+   */
+  onClick?: (e: ThreeEvent<Mesh>) => void;
+  /**
+   * Pointer out event handler
+   * @default empty function
+   */
+  onPointerOut?: (e: ThreeEvent<Mesh>) => void;
+  /**
+   * Pointer over event handler
+   * @default empty function
+   */
+  onPointerOver?: (e: ThreeEvent<Mesh>) => void;
+  /**
    * Side to render: front, back, or double.
    * @default "double"
    */
@@ -60,6 +76,9 @@ const GeoPolygon = ({
   color = "#ff0000",
   opacity = 1,
   isWireframe = false,
+  onClick = () => {},
+  onPointerOut = () => {},
+  onPointerOver = () => {},
   side = "double",
 }: GeoPolygonProps) => {
   const geo = useGeolocationBackend();
@@ -172,7 +191,12 @@ const GeoPolygon = ({
     <group>
       {geometryData && (
         <group position={[0, geometryData.avgElevation, 0]}>
-          <mesh geometry={geometryData.geometry}>
+          <mesh
+            geometry={geometryData.geometry}
+            onClick={onClick}
+            onPointerOut={onPointerOut}
+            onPointerOver={onPointerOver}
+          >
             <meshBasicMaterial
               color={color}
               opacity={opacity}

--- a/packages/rdk/src/geolocation/GeoPolygon.tsx
+++ b/packages/rdk/src/geolocation/GeoPolygon.tsx
@@ -14,7 +14,7 @@ import useGeolocationBackend from "./useGeolocationBackend";
 
 import type { ThreeEvent } from "@react-three/fiber";
 import type { LocAR } from "locar";
-import type { Mesh, Side } from "three";
+import type { Side } from "three";
 
 export interface GeoPolygonProps {
   /** Outer ring coordinates. GeoJSON-style: [lon, lat, elevation?] */
@@ -39,20 +39,17 @@ export interface GeoPolygonProps {
    */
   isWireframe?: boolean;
   /**
-   * Click event handler
-   * @default empty function
+   * Click event handler. When omitted, the polygon is not registered for pointer raycasting.
    */
-  onClick?: (e: ThreeEvent<Mesh>) => void;
+  onClick?: (e: ThreeEvent<MouseEvent>) => void;
   /**
-   * Pointer out event handler
-   * @default empty function
+   * Pointer out event handler. When omitted, the polygon is not registered for pointer raycasting.
    */
-  onPointerOut?: (e: ThreeEvent<Mesh>) => void;
+  onPointerOut?: (e: ThreeEvent<PointerEvent>) => void;
   /**
-   * Pointer over event handler
-   * @default empty function
+   * Pointer over event handler. When omitted, the polygon is not registered for pointer raycasting.
    */
-  onPointerOver?: (e: ThreeEvent<Mesh>) => void;
+  onPointerOver?: (e: ThreeEvent<PointerEvent>) => void;
   /**
    * Side to render: front, back, or double.
    * @default "double"
@@ -76,9 +73,9 @@ const GeoPolygon = ({
   color = "#ff0000",
   opacity = 1,
   isWireframe = false,
-  onClick = () => {},
-  onPointerOut = () => {},
-  onPointerOver = () => {},
+  onClick,
+  onPointerOut,
+  onPointerOver,
   side = "double",
 }: GeoPolygonProps) => {
   const geo = useGeolocationBackend();
@@ -191,6 +188,7 @@ const GeoPolygon = ({
     <group>
       {geometryData && (
         <group position={[0, geometryData.avgElevation, 0]}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: <mesh> is an R3F WebGL scene object, not a DOM element; these are three.js raycast events with no a11y semantics */}
           <mesh
             geometry={geometryData.geometry}
             onClick={onClick}


### PR DESCRIPTION

## Description

Allows `GeoLine` and `GeoPolygon` elements to be clickable and handle `pointerover` and `pointerout` events.

Added `onClick`, `onPointerOver` and `onPointerOut` attributes to the above components. These are forwarded to the appropriate mesh or group.

NOTE that I had to set the Biome accessibility rule `noStaticElementInteractions` to `warn` to allow the commit to be accepted. Biome was giving an error due to adding event handlers to non-input elements. I realise this is a bit quick and dirty, but the rule is presumably aimed more at HTML elements. @coopbri not sure what you want to do about this?

## Test Steps

Geolocation test app shows examples of `onClick` handlers on the two `GeoLine`s and the `GeoPolygon`. Tested the app on a desktop machine - confirmed as working.

