### PR TITLE
Remove resize handler from geolocationBackend

### DIFF
--- a/apps/geolocation-demo/src/App.tsx
+++ b/apps/geolocation-demo/src/App.tsx
@@ -162,8 +162,8 @@ const App = () => {
           options={{
             // enable fake GPS for testing on desktop: uncomment and adjust
             // (example: Missoula, MT)
-            // fakeLat: 46.8721,
-            // fakeLon: -114.009,
+            fakeLat: 46.8721,
+            fakeLon: -114.009,
             onGpsUpdate: (pos) => {
               // lock the base to the first GPS fix
               setBase((prev) =>

--- a/apps/geolocation-demo/src/App.tsx
+++ b/apps/geolocation-demo/src/App.tsx
@@ -162,8 +162,8 @@ const App = () => {
           options={{
             // enable fake GPS for testing on desktop: uncomment and adjust
             // (example: Missoula, MT)
-            fakeLat: 46.8721,
-            fakeLon: -114.009,
+            // fakeLat: 46.8721,
+            // fakeLon: -114.009,
             onGpsUpdate: (pos) => {
               // lock the base to the first GPS fix
               setBase((prev) =>

--- a/packages/rdk/src/geolocation/geolocationBackend.ts
+++ b/packages/rdk/src/geolocation/geolocationBackend.ts
@@ -92,7 +92,6 @@ const createGeolocationBackend = (
   // against our existing (react-three-fiber owned) camera, renderer and scene
   let app: App | null = null;
   let locar: LocAR | null = null;
-  let resizeHandler: (() => void) | undefined;
 
   let gpsUpdateHandler: ((data: GpsUpdateEvent) => void) | null = null;
 
@@ -288,11 +287,6 @@ const createGeolocationBackend = (
       rendererRef?.setClearAlpha?.(1);
 
       app?.deviceOrientationControls?.dispose?.();
-
-      if (resizeHandler) {
-        window.removeEventListener("resize", resizeHandler);
-        resizeHandler = undefined;
-      }
 
       // clean up all anchors
       for (const entry of anchorRegistry.values()) {

--- a/packages/rdk/src/geolocation/geolocationBackend.ts
+++ b/packages/rdk/src/geolocation/geolocationBackend.ts
@@ -267,27 +267,6 @@ const createGeolocationBackend = (
           toJSON: () => lastLocation,
         };
       }
-
-      // handle resize
-      const doResize = () => {
-        if (!rendererRef || !cameraRef) return;
-
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-
-        rendererRef.setSize(w, h, false);
-
-        // camera can be perspective or other
-        // TODO improve this, these attributes are part of Three.js perspective cameras (https://threejs.org/docs/#PerspectiveCamera); figure whether custom cameras should be allowed here or if it should be narrowed to perspective cameras
-        (cameraRef as any).aspect = w / h;
-        (cameraRef as any).updateProjectionMatrix?.();
-      };
-
-      doResize();
-
-      window.addEventListener("resize", doResize);
-
-      resizeHandler = doResize;
     },
 
     update() {


### PR DESCRIPTION
## Description

Removed resize handler from `geolocationBackend.ts`.
I don't believe it's necessary as React Three Fiber handles resize itself, and we're now using the R3F renderer rather than a separate Locar one.

## Test Steps

Tested the geolocation demo on a desktop environment. Same behaviour on resize as before. 