### PR TITLE
fix(build): resolve internal modules via @/ alias instead of baseUrl

### DIFF
--- a/.changeset/tsconfig-baseurl-to-paths.md
+++ b/.changeset/tsconfig-baseurl-to-paths.md
@@ -1,0 +1,9 @@
+---
+"@omnidotdev/rdk": patch
+---
+
+fix(build): resolve internal modules via a `@/` alias instead of `baseUrl`
+
+TypeScript 7 removed the `baseUrl` compiler option, which the package relied on to resolve `src`-relative bare imports (e.g. `engine/useXRStore`, `lib/types/engine`). Under TS 7 this broke `vite-tsconfig-paths` resolution, failing the Vitest suite and the library build (including `.d.ts` emission).
+
+Replace `baseUrl` with an explicit `@/*` -> `./src/*` path mapping and migrate internal imports to the `@/` prefix. Unlike bare `src`-relative imports, the `@/` prefix cannot collide with npm package names, so a future dependency named `engine`, `lib`, `vision`, etc. can no longer shadow local modules. `vite-tsconfig-paths` is now the single resolver for both build and test (the redundant Vitest `resolve.alias` was removed).

--- a/apps/fiducial-demo/src/App.tsx
+++ b/apps/fiducial-demo/src/App.tsx
@@ -1,6 +1,7 @@
 import { FiducialAnchor, FiducialSession, XR } from "@omnidotdev/rdk";
 import { Canvas } from "@react-three/fiber";
-import { Supertorus } from "components";
+
+import { Supertorus } from "@/components";
 
 /**
  * Fiducial marker-based AR demo application.

--- a/apps/fiducial-demo/tsconfig.json
+++ b/apps/fiducial-demo/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/geolocation-demo/src/App.tsx
+++ b/apps/geolocation-demo/src/App.tsx
@@ -6,8 +6,9 @@ import {
   XR,
 } from "@omnidotdev/rdk";
 import { Canvas } from "@react-three/fiber";
-import { Compass, GPSPin, Landmark } from "components";
 import { useState } from "react";
+
+import { Compass, GPSPin, Landmark } from "@/components";
 
 interface LatLon {
   lat: number;

--- a/apps/geolocation-demo/tsconfig.json
+++ b/apps/geolocation-demo/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/immersive-demo/tsconfig.json
+++ b/apps/immersive-demo/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/magic-demo/src/App.tsx
+++ b/apps/magic-demo/src/App.tsx
@@ -1,6 +1,7 @@
 import { MagicSession, WorldAnchor, XR } from "@omnidotdev/rdk";
 import { Canvas } from "@react-three/fiber";
-import { FloatingCrystal, OrientationHUD } from "components";
+
+import { FloatingCrystal, OrientationHUD } from "@/components";
 
 const App = () => (
   <>

--- a/apps/magic-demo/tsconfig.json
+++ b/apps/magic-demo/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/vision-demo/src/App.tsx
+++ b/apps/vision-demo/src/App.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import {
   FaceMode,
   HandMode,
@@ -5,11 +7,10 @@ import {
   ObjectMode,
   PoseMode,
   SegmentMode,
-} from "components";
-import { useState } from "react";
+} from "@/components";
 
 import type { VisionTask } from "@omnidotdev/rdk/vision";
-import type { Mode } from "components";
+import type { Mode } from "@/components";
 
 const MODE_TASKS: Record<"hands" | "faces" | "poses", VisionTask[]> = {
   hands: ["hands"],

--- a/apps/vision-demo/tsconfig.json
+++ b/apps/vision-demo/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/rdk/src/engine/useXRStore.test.ts
+++ b/packages/rdk/src/engine/useXRStore.test.ts
@@ -1,11 +1,11 @@
 import { act } from "@testing-library/react";
-import { BACKEND_TYPES } from "lib/types/engine";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { BACKEND_TYPES } from "@/lib/types/engine";
 import useXRStore, { getXRStore } from "./useXRStore";
 
-import type { Backend, BackendType } from "lib/types/engine";
 import type { Camera, Scene, WebGLRenderer } from "three";
+import type { Backend, BackendType } from "@/lib/types/engine";
 
 // Mock @react-three/xr
 vi.mock("@react-three/xr", () => ({

--- a/packages/rdk/src/engine/useXRStore.ts
+++ b/packages/rdk/src/engine/useXRStore.ts
@@ -1,11 +1,12 @@
-import { BACKEND_TYPES } from "lib/types/engine";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
 
+import { BACKEND_TYPES } from "@/lib/types/engine";
+
 import type { XRStore as ReactThreeXRStore } from "@react-three/xr";
-import type { Backend, BackendType } from "lib/types/engine";
 import type { Camera, Scene, WebGLRenderer } from "three";
+import type { Backend, BackendType } from "@/lib/types/engine";
 
 interface BaseXRStoreState {
   /** Shared video element. */

--- a/packages/rdk/src/fiducial/FiducialSession.tsx
+++ b/packages/rdk/src/fiducial/FiducialSession.tsx
@@ -1,10 +1,11 @@
 import { useThree } from "@react-three/fiber";
-import useXRStore from "engine/useXRStore";
-import { createFiducialBackend } from "fiducial";
 import { useEffect, useRef } from "react";
 
-import type { Backend } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { createFiducialBackend } from "@/fiducial";
+
 import type { PropsWithChildren } from "react";
+import type { Backend } from "@/lib/types/engine";
 // NB: relative type import path resolves downstream type issues
 import type { FiducialSessionOptions } from "./fiducialBackend";
 

--- a/packages/rdk/src/fiducial/fiducialBackend.ts
+++ b/packages/rdk/src/fiducial/fiducialBackend.ts
@@ -2,11 +2,12 @@ import {
   ArToolkitContext,
   ArToolkitSource,
 } from "@ar-js-org/ar.js/three.js/build/ar-threex";
-import { BACKEND_TYPES } from "lib/types/engine";
+
+import { BACKEND_TYPES } from "@/lib/types/engine";
 
 import type { ArToolkitContextParameters } from "@ar-js-org/ar.js/three.js/build/ar-threex";
-import type { Backend, BackendInitArgs } from "lib/types/engine";
 import type { Camera } from "three";
+import type { Backend, BackendInitArgs } from "@/lib/types/engine";
 
 /**
  * Internal state exposed by the fiducial backend.

--- a/packages/rdk/src/fiducial/useFiducialBackend.ts
+++ b/packages/rdk/src/fiducial/useFiducialBackend.ts
@@ -1,5 +1,5 @@
-import useXRStore from "engine/useXRStore";
-import { BACKEND_TYPES } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { BACKEND_TYPES } from "@/lib/types/engine";
 
 import type { FiducialBackendState, FiducialInternal } from "./fiducialBackend";
 

--- a/packages/rdk/src/geolocation/GeolocationSession.tsx
+++ b/packages/rdk/src/geolocation/GeolocationSession.tsx
@@ -1,10 +1,11 @@
 import { useThree } from "@react-three/fiber";
-import useXRStore from "engine/useXRStore";
-import { createGeolocationBackend } from "geolocation";
 import { useEffect, useRef } from "react";
 
-import type { Backend } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { createGeolocationBackend } from "@/geolocation";
+
 import type { PropsWithChildren } from "react";
+import type { Backend } from "@/lib/types/engine";
 // NB: relative type import path resolves downstream type issues
 import type { GeolocationSessionOptions } from "./geolocationBackend";
 

--- a/packages/rdk/src/geolocation/geolocationBackend.ts
+++ b/packages/rdk/src/geolocation/geolocationBackend.ts
@@ -1,7 +1,7 @@
-import { BACKEND_TYPES } from "lib/types/engine";
 import { App } from "locar";
 
-import type { Backend, BackendInitArgs } from "lib/types/engine";
+import { BACKEND_TYPES } from "@/lib/types/engine";
+
 import type { DeviceOrientationControls, LocAR, Webcam } from "locar";
 import type {
   Camera,
@@ -10,6 +10,7 @@ import type {
   Scene,
   WebGLRenderer,
 } from "three";
+import type { Backend, BackendInitArgs } from "@/lib/types/engine";
 
 /**
  * GPS update event structure emitted by LocAR.

--- a/packages/rdk/src/geolocation/useGeolocationBackend.ts
+++ b/packages/rdk/src/geolocation/useGeolocationBackend.ts
@@ -1,5 +1,5 @@
-import useXRStore from "engine/useXRStore";
-import { BACKEND_TYPES } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { BACKEND_TYPES } from "@/lib/types/engine";
 
 import type {
   GeolocationBackendState,

--- a/packages/rdk/src/immersive/ImmersiveSession.tsx
+++ b/packages/rdk/src/immersive/ImmersiveSession.tsx
@@ -1,11 +1,11 @@
 import { createXRStore, XR as ReactThreeXR } from "@react-three/xr";
-import { BACKEND_TYPES } from "lib/types/engine";
 import { useEffect, useMemo } from "react";
 
+import { BACKEND_TYPES } from "@/lib/types/engine";
 import { getXRStore } from "../engine/useXRStore";
 
-import type { Backend } from "lib/types/engine";
 import type { PropsWithChildren } from "react";
+import type { Backend } from "@/lib/types/engine";
 
 /**
  * Create a minimal immersive backend for tracking purposes.

--- a/packages/rdk/src/magic/MagicSession.tsx
+++ b/packages/rdk/src/magic/MagicSession.tsx
@@ -1,11 +1,11 @@
 import { useThree } from "@react-three/fiber";
-import useXRStore from "engine/useXRStore";
 import { useEffect, useRef } from "react";
 
+import useXRStore from "@/engine/useXRStore";
 import createMagicBackend from "./magicBackend";
 
-import type { Backend } from "lib/types/engine";
 import type { PropsWithChildren } from "react";
+import type { Backend } from "@/lib/types/engine";
 // NB: relative type import path resolves downstream type issues
 import type { MagicSessionOptions } from "./magicBackend";
 

--- a/packages/rdk/src/magic/WorldAnchor.tsx
+++ b/packages/rdk/src/magic/WorldAnchor.tsx
@@ -1,11 +1,12 @@
 import { useFrame } from "@react-three/fiber";
-import useXRStore from "engine/useXRStore";
-import { BACKEND_TYPES } from "lib/types/engine";
 import { useRef } from "react";
 
-import type { Backend } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { BACKEND_TYPES } from "@/lib/types/engine";
+
 import type { PropsWithChildren } from "react";
 import type { Group } from "three";
+import type { Backend } from "@/lib/types/engine";
 import type { MagicInternal } from "./magicBackend";
 
 export interface WorldAnchorProps extends PropsWithChildren {

--- a/packages/rdk/src/magic/magicBackend.ts
+++ b/packages/rdk/src/magic/magicBackend.ts
@@ -1,7 +1,8 @@
-import { BACKEND_TYPES } from "lib/types/engine";
 import * as THREE from "three";
 
-import type { Backend, BackendInitArgs } from "lib/types/engine";
+import { BACKEND_TYPES } from "@/lib/types/engine";
+
+import type { Backend, BackendInitArgs } from "@/lib/types/engine";
 
 /**
  * Internal state exposed by the magic window backend.

--- a/packages/rdk/src/vision/VisionSession.tsx
+++ b/packages/rdk/src/vision/VisionSession.tsx
@@ -1,11 +1,11 @@
 import { useThree } from "@react-three/fiber";
-import useXRStore from "engine/useXRStore";
 import { useEffect, useRef } from "react";
 
+import useXRStore from "@/engine/useXRStore";
 import createVisionBackend from "./visionBackend";
 
-import type { Backend } from "lib/types/engine";
 import type React from "react";
+import type { Backend } from "@/lib/types/engine";
 import type { VisionSessionOptions } from "./types";
 
 export type VisionSessionProps = {

--- a/packages/rdk/src/vision/useVisionBackend.ts
+++ b/packages/rdk/src/vision/useVisionBackend.ts
@@ -1,5 +1,5 @@
-import useXRStore from "engine/useXRStore";
-import { BACKEND_TYPES } from "lib/types/engine";
+import useXRStore from "@/engine/useXRStore";
+import { BACKEND_TYPES } from "@/lib/types/engine";
 
 import type { VisionBackendState, VisionInternal } from "./visionBackend";
 

--- a/packages/rdk/src/vision/visionBackend.test.ts
+++ b/packages/rdk/src/vision/visionBackend.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createVisionProvider } from "./providers";
 import createVisionBackend from "./visionBackend";
 
-import type { BackendInitArgs } from "lib/types/engine";
+import type { BackendInitArgs } from "@/lib/types/engine";
 import type { VisionFrame } from "./types";
 
 // Shared mock provider state (hoisted above the vi.mock factory)

--- a/packages/rdk/src/vision/visionBackend.ts
+++ b/packages/rdk/src/vision/visionBackend.ts
@@ -1,8 +1,7 @@
-import { BACKEND_TYPES } from "lib/types/engine";
-
+import { BACKEND_TYPES } from "@/lib/types/engine";
 import { createVisionProvider } from "./providers";
 
-import type { Backend, BackendInitArgs } from "lib/types/engine";
+import type { Backend, BackendInitArgs } from "@/lib/types/engine";
 import type {
   VisionFrame,
   VisionProvider,

--- a/packages/rdk/tsconfig.json
+++ b/packages/rdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "baseUrl": "src",
+    "paths": { "@/*": ["./src/*"] },
     "declaration": true,
     "declarationMap": true,
     "isolatedModules": true,

--- a/packages/rdk/vitest.config.ts
+++ b/packages/rdk/vitest.config.ts
@@ -1,5 +1,3 @@
-import { resolve } from "node:path";
-
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
@@ -23,11 +21,6 @@ const vitestConfig = defineConfig({
         url: "http://localhost:3000",
         pretendToBeVisual: true,
       },
-    },
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
     },
   },
   esbuild: {


### PR DESCRIPTION
## Description

The test suite and library build have been broken on `master` since #112. That PR bumped `typescript` `^5.9.3` -> `^7.0.0`, and **TypeScript 7 removed the `baseUrl` compiler option**, which the package relied on to resolve its `src`-relative bare imports (e.g. `engine/useXRStore`, `lib/types/engine`). Under TS 7, `vite-tsconfig-paths` could no longer rewrite those imports, so:

- **11 Vitest files failed to load** with `Cannot find package 'engine/useXRStore'` / `lib/types/engine`
- The 2 `mediapipeProvider` assertion failures were downstream of the same break (broken resolution duplicated a module, so the landmarker mocks were invoked twice)
- The library **build** and **`.d.ts` emission** failed the same way (the build uses the same resolver)

### Fix

Migrate module resolution to an explicit `@/` alias instead of the removed `baseUrl`:

- `baseUrl: "src"` -> `paths: { "@/*": ["./src/*"] }` in the package and all demo tsconfigs
- Migrate internal imports to the `@/` prefix across the package and demos
- Remove the redundant Vitest `resolve.alias`, so `vite-tsconfig-paths` is the single resolver for both build and test

Unlike bare `src`-relative specifiers, `@/` cannot collide with npm package names, so a future dependency named `engine`, `lib`, `vision`, etc. can no longer shadow local modules. This is the resolution style the repo had already declared (the `@` alias in `vitest.config.ts`) but never applied.

## Test Steps

Validated locally under bun:

- `bun run test` (rdk): **121/121 pass** (18 files; was 11 files failing to load)
- `bun run build` (root, turbo): **6/6 pass** (package + all 5 demos), `.d.ts` emitted
- `bun run check` (Biome CI gate): clean

### Follow-up (not in this PR)

Vite 8 now resolves tsconfig paths natively (`resolve.tsconfigPaths: true`) and advises dropping `vite-tsconfig-paths`. Worth a separate PR since it touches all 6 vite configs and removes a dependency.