### PR TITLE
chore(build): use Vite native tsconfig paths, silence typescript6 knip false positive

### DIFF
--- a/apps/fiducial-demo/package.json
+++ b/apps/fiducial-demo/package.json
@@ -19,8 +19,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^7.0.0",
     "vite": "^8.0.0",
-    "vite-plugin-mkcert": "^2.0.0",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-plugin-mkcert": "^2.0.0"
   },
   "dependencies": {
     "@ar-js-org/ar.js": "^3.4.7",

--- a/apps/fiducial-demo/vite.config.ts
+++ b/apps/fiducial-demo/vite.config.ts
@@ -1,14 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import mkcert from "vite-plugin-mkcert";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * Vite configuration.
  * @see https://vite.dev/config
  */
 const viteConfig = defineConfig({
-  plugins: [react(), mkcert(), tsconfigPaths()],
+  plugins: [react(), mkcert()],
   server: {
     host: true,
     port: 3000,
@@ -18,6 +17,8 @@ const viteConfig = defineConfig({
   },
   publicDir: "public",
   resolve: {
+    // Vite 8 resolves tsconfig paths (the @/ alias) natively
+    tsconfigPaths: true,
     alias: {
       react: "react",
       "react-dom": "react-dom",

--- a/apps/geolocation-demo/package.json
+++ b/apps/geolocation-demo/package.json
@@ -19,8 +19,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^7.0.0",
     "vite": "^8.0.0",
-    "vite-plugin-mkcert": "^2.0.0",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-plugin-mkcert": "^2.0.0"
   },
   "dependencies": {
     "@omnidotdev/rdk": "workspace:*",

--- a/apps/geolocation-demo/vite.config.ts
+++ b/apps/geolocation-demo/vite.config.ts
@@ -1,14 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import mkcert from "vite-plugin-mkcert";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * Vite configuration.
  * @see https://vite.dev/config
  */
 const viteConfig = defineConfig({
-  plugins: [react(), mkcert(), tsconfigPaths()],
+  plugins: [react(), mkcert()],
   server: {
     host: true,
     port: 3000,
@@ -18,6 +17,8 @@ const viteConfig = defineConfig({
   },
   publicDir: "public",
   resolve: {
+    // Vite 8 resolves tsconfig paths (the @/ alias) natively
+    tsconfigPaths: true,
     alias: {
       react: "react",
       "react-dom": "react-dom",

--- a/apps/immersive-demo/package.json
+++ b/apps/immersive-demo/package.json
@@ -19,8 +19,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "~7.0.0",
     "vite": "^8.0.0",
-    "vite-plugin-mkcert": "^2.0.0",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-plugin-mkcert": "^2.0.0"
   },
   "dependencies": {
     "@omnidotdev/rdk": "workspace:*",

--- a/apps/immersive-demo/vite.config.ts
+++ b/apps/immersive-demo/vite.config.ts
@@ -1,14 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import mkcert from "vite-plugin-mkcert";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * Vite configuration.
  * @see https://vite.dev/config
  */
 const viteConfig = defineConfig({
-  plugins: [react(), mkcert(), tsconfigPaths()],
+  plugins: [react(), mkcert()],
   server: {
     host: true,
     port: 3000,
@@ -18,6 +17,8 @@ const viteConfig = defineConfig({
   },
   publicDir: "public",
   resolve: {
+    // Vite 8 resolves tsconfig paths (the @/ alias) natively
+    tsconfigPaths: true,
     alias: {
       react: "react",
       "react-dom": "react-dom",

--- a/apps/magic-demo/package.json
+++ b/apps/magic-demo/package.json
@@ -19,8 +19,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^7.0.0",
     "vite": "^8.0.0",
-    "vite-plugin-mkcert": "^2.0.0",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-plugin-mkcert": "^2.0.0"
   },
   "dependencies": {
     "@omnidotdev/rdk": "workspace:*",

--- a/apps/magic-demo/vite.config.ts
+++ b/apps/magic-demo/vite.config.ts
@@ -1,14 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import mkcert from "vite-plugin-mkcert";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * Vite configuration.
  * @see https://vite.dev/config
  */
 const viteConfig = defineConfig({
-  plugins: [react(), mkcert(), tsconfigPaths()],
+  plugins: [react(), mkcert()],
   server: {
     host: true,
     port: 3000,
@@ -18,6 +17,8 @@ const viteConfig = defineConfig({
   },
   publicDir: "public",
   resolve: {
+    // Vite 8 resolves tsconfig paths (the @/ alias) natively
+    tsconfigPaths: true,
     alias: {
       react: "react",
       "react-dom": "react-dom",

--- a/apps/vision-demo/package.json
+++ b/apps/vision-demo/package.json
@@ -20,8 +20,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^7.0.0",
     "vite": "^8.0.0",
-    "vite-plugin-mkcert": "^1.17.9",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-plugin-mkcert": "^1.17.9"
   },
   "dependencies": {
     "@mediapipe/tasks-vision": "^0.10.0",

--- a/apps/vision-demo/vite.config.ts
+++ b/apps/vision-demo/vite.config.ts
@@ -3,14 +3,13 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import mkcert from "vite-plugin-mkcert";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * Vite configuration.
  * @see https://vite.dev/config
  */
 const viteConfig = defineConfig({
-  plugins: [react(), mkcert(), tsconfigPaths()],
+  plugins: [react(), mkcert()],
   server: {
     host: true,
     port: 3000,
@@ -25,6 +24,8 @@ const viteConfig = defineConfig({
     exclude: ["@omnidotdev/rdk"],
   },
   resolve: {
+    // Vite 8 resolves tsconfig paths (the @/ alias) natively
+    tsconfigPaths: true,
     alias: {
       // Resolve to source so Vite handles the worker natively
       "@omnidotdev/rdk/vision": resolve(

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "typescript": "^7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-mkcert": "^2.0.0",
-        "vite-tsconfig-paths": "^6.0.3",
       },
     },
     "apps/geolocation-demo": {
@@ -55,7 +54,6 @@
         "typescript": "^7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-mkcert": "^2.0.0",
-        "vite-tsconfig-paths": "^6.0.3",
       },
     },
     "apps/immersive-demo": {
@@ -78,7 +76,6 @@
         "typescript": "~7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-mkcert": "^2.0.0",
-        "vite-tsconfig-paths": "^6.0.3",
       },
     },
     "apps/magic-demo": {
@@ -99,7 +96,6 @@
         "typescript": "^7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-mkcert": "^2.0.0",
-        "vite-tsconfig-paths": "^6.0.3",
       },
     },
     "apps/vision-demo": {
@@ -122,7 +118,6 @@
         "typescript": "^7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-mkcert": "^1.17.9",
-        "vite-tsconfig-paths": "^6.0.3",
       },
     },
     "packages/rdk": {
@@ -152,7 +147,6 @@
         "typescript": "^7.0.0",
         "vite": "^8.0.0",
         "vite-plugin-dts": "^5.0.0",
-        "vite-tsconfig-paths": "^6.0.3",
         "vitest": "^4.0.16",
       },
       "peerDependencies": {
@@ -862,8 +856,6 @@
 
     "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
 
-    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
-
     "glsl-noise": ["glsl-noise@0.0.0", "", {}, "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
@@ -1222,8 +1214,6 @@
 
     "ts-proto-descriptors": ["ts-proto-descriptors@2.1.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0" } }, "sha512-S5EZYEQ6L9KLFfjSRpZWDIXDV/W7tAj8uW7pLsihIxyr62EAVSiKuVPwE8iWnr849Bqa53enex1jhDUcpgquzA=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
 
     "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
@@ -1267,8 +1257,6 @@
     "vite-plugin-dts": ["vite-plugin-dts@5.0.3", "", { "dependencies": { "unplugin-dts": "1.0.3" }, "peerDependencies": { "@microsoft/api-extractor": ">=7", "rollup": ">=3", "vite": ">=3" }, "optionalPeers": ["@microsoft/api-extractor", "rollup", "vite"] }, "sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ=="],
 
     "vite-plugin-mkcert": ["vite-plugin-mkcert@2.1.0", "", { "dependencies": { "debug": "^4.4.3", "supports-color": "^10.2.2", "undici": "^8.3.0" }, "peerDependencies": { "vite": ">=3" } }, "sha512-UQS5iyknruwCsvqDPsKRyHIVSVfv/iGdRPmUPaM1JRwNJo8wo/MubzJ66ckWwOLxFU4wW90oZq9GviV87nRHsg=="],
-
-    "vite-tsconfig-paths": ["vite-tsconfig-paths@6.0.3", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-7bL7FPX/DSviaZGYUKowWF1AiDVWjMjxNbE8lyaVGDezkedWqfGhlnQ4BZXre0ZN5P4kAgIJfAlgFDVyjrCIyg=="],
 
     "vitest": ["vitest@4.0.16", "", { "dependencies": { "@vitest/expect": "4.0.16", "@vitest/mocker": "4.0.16", "@vitest/pretty-format": "4.0.16", "@vitest/runner": "4.0.16", "@vitest/snapshot": "4.0.16", "@vitest/spy": "4.0.16", "@vitest/utils": "4.0.16", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.16", "@vitest/browser-preview": "4.0.16", "@vitest/browser-webdriverio": "4.0.16", "@vitest/ui": "4.0.16", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q=="],
 

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "packages/*": {
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": ["@typescript/typescript6"]
     },
     "apps/*": {
       "project": ["src/**/*.{ts,tsx}"]

--- a/packages/rdk/package.json
+++ b/packages/rdk/package.json
@@ -120,7 +120,6 @@
     "typescript": "^7.0.0",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^5.0.0",
-    "vite-tsconfig-paths": "^6.0.3",
     "vitest": "^4.0.16"
   },
   "dependencies": {

--- a/packages/rdk/vite.config.ts
+++ b/packages/rdk/vite.config.ts
@@ -2,7 +2,6 @@ import { resolve } from "node:path";
 
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 /** Peer dependencies kept external (never bundled into the published package) */
 const EXTERNAL_DEPS = [
@@ -26,7 +25,6 @@ const isExternal = (id: string): boolean =>
  */
 const viteConfig = defineConfig(({ mode }) => ({
   plugins: [
-    tsconfigPaths(),
     dts({
       insertTypesEntry: true,
       include: ["src/**/*"],
@@ -34,6 +32,10 @@ const viteConfig = defineConfig(({ mode }) => ({
       outDir: "build",
     }),
   ],
+  // Vite 8 resolves tsconfig `paths` (the `@/*` alias) natively
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: "build",
     lib: {

--- a/packages/rdk/vitest.config.ts
+++ b/packages/rdk/vitest.config.ts
@@ -1,4 +1,5 @@
-import tsconfigPaths from "vite-tsconfig-paths";
+import { resolve } from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 /**
@@ -6,7 +7,13 @@ import { defineConfig } from "vitest/config";
  * @see https://vitest.dev/config
  */
 const vitestConfig = defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vitest 4 does not honor Vite's native `resolve.tsconfigPaths`, so map the
+  // `@/*` alias explicitly here (the Vite build uses native resolution instead)
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Description

Two build-tooling cleanups, both with **no effect on the published package**:

1. **Replace the `vite-tsconfig-paths` plugin with Vite 8's native `resolve.tsconfigPaths`** in the library and demo Vite builds, per Vite's own boot advisory. Vitest 4 does not yet honor the native option, so its config maps the `@/*` alias explicitly instead. The plugin dependency is removed from all six workspaces.
2. **Keep `@typescript/typescript6` and add a Knip ignore for it.** Knip flagged it as unused, but `unplugin-dts` requires it as the JavaScript Compiler API fallback for `.d.ts` emission under TypeScript 7 (removing it fails a clean build with `The installed "typescript" package does not provide the JavaScript Compiler API ... the fallback "@typescript/typescript6" was not found`). It is a dynamic runtime fallback, not a static import, so Knip cannot see the usage: a false positive, added to `ignoreDependencies`.

No changeset: build-config only, byte-identical published output.

## Test Steps

Validated locally under bun with a **clean install** (`rm -rf node_modules && bun install`) to avoid stale-store false positives:

- `bun run build` (root, turbo): **6/6 pass** (package + 5 demos), `.d.ts` emitted, plugin advisory gone
- `bun run test` (rdk): **121/121 pass**
- `bun run knip`: clean
- `bun run check` (Biome CI gate): clean