### PR TITLE
refactor(magic): delegate resize to R3F, drop redundant window handler

### DIFF
--- a/packages/rdk/src/magic/magicBackend.ts
+++ b/packages/rdk/src/magic/magicBackend.ts
@@ -60,7 +60,6 @@ const createMagicBackend = (
   let videoElement: HTMLVideoElement | null = null;
   let videoTexture: THREE.VideoTexture | null = null;
   let stream: MediaStream | null = null;
-  let resizeHandler: (() => void) | undefined;
 
   // Orientation state
   let orientationEnabled = options?.enableOrientation ?? true;
@@ -312,26 +311,6 @@ const createMagicBackend = (
           document.addEventListener("touchend", retryOnGesture);
         }
       }
-
-      // Handle resize
-      const doResize = () => {
-        if (!rendererRef || !cameraRef) return;
-
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-
-        rendererRef.setSize(w, h, false);
-
-        // Update camera aspect ratio
-        // TODO improve this, these attributes are part of Three.js perspective cameras; figure whether custom cameras should be allowed here
-        (cameraRef as any).aspect = w / h;
-        (cameraRef as any).updateProjectionMatrix?.();
-      };
-
-      doResize();
-
-      window.addEventListener("resize", doResize);
-      resizeHandler = doResize;
     },
 
     update() {
@@ -406,12 +385,6 @@ const createMagicBackend = (
         document.removeEventListener("click", gestureRetryHandler);
         document.removeEventListener("touchend", gestureRetryHandler);
         gestureRetryHandler = null;
-      }
-
-      // Remove resize handler
-      if (resizeHandler) {
-        window.removeEventListener("resize", resizeHandler);
-        resizeHandler = undefined;
       }
 
       // Stop media stream tracks


### PR DESCRIPTION
## Description

`MagicSession` passes the react-three-fiber `camera` and renderer (`gl`, from `useThree()`) into the backend, so R3F's `<Canvas>` already runs `setSize` and updates the camera aspect / `updateProjectionMatrix` on resize. The backend's own `window` resize handler only duplicated that:

- the camera is a standard perspective camera with **no custom projection** (unlike `fiducialBackend`, which copies AR.js's projection matrix), so letting R3F own the aspect is correct
- the passthrough video is a **CSS fullscreen element** (`width:100vw; height:100vh; object-fit:cover`) that resizes itself, and its `scene.background` VideoTexture is fit by three per-frame

So the handler is removed, along with the now-orphaned `resizeHandler` declaration and teardown block. Mirrors the geolocation change in #123.

Note: `fiducialBackend` intentionally keeps its handler; it does AR.js-specific work (`arSource.onResizeElement()`, `copyElementSizeTo`) and drives a custom projection, so it is not redundant.

No changeset: equivalent runtime behavior (resize delegated to R3F), internal refactor.

## Test Steps

- `bun run test` (rdk): 121/121 pass
- `bun run check` (Biome CI gate): clean

Worth a quick on-device sanity check that magic-window resize still looks right, same as #123.